### PR TITLE
Removed default_value, updated api annotations, added HTTP error response object

### DIFF
--- a/protobuf/v1/schema.proto
+++ b/protobuf/v1/schema.proto
@@ -7,7 +7,7 @@ option go_package = "schema/service/v1";
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
 
-message HTTPErrorResponse {
+message ErrorResponse {
     string error_code = 1;
 }
 


### PR DESCRIPTION
Removed default_value:
https://github.com/open-feature/flagd/issues/69

Updated API Annotations:
mapped the body of HTTP requests directly to context

HTTP error response object:
HTTPErrorResponse will be used for spec compliant error responses  (error_code to be provided in body of response)

Signed-off-by: James-Milligan <james@omnant.co.uk>