### PR TITLE
feat: removed state as required property. Allowed variants of boolean flag to be null

### DIFF
--- a/json/flagd-definitions.json
+++ b/json/flagd-definitions.json
@@ -48,7 +48,8 @@
           "enum": [
             "ENABLED",
             "DISABLED"
-          ]
+          ],
+          "default": "ENABLED"
         },
         "defaultVariant": {
           "description": "The variant to serve if no dynamic targeting applies",
@@ -60,7 +61,6 @@
         }
       },
       "required": [
-        "state",
         "defaultVariant"
       ]
     },
@@ -94,7 +94,10 @@
             }
           }
         }
-      }
+      },
+      "required": [
+        "variants"
+      ]
     },
     "numberVariants": {
       "type": "object",
@@ -108,7 +111,10 @@
             }
           }
         }
-      }
+      },
+      "required": [
+        "variants"
+      ]
     },
     "objectVariants": {
       "type": "object",
@@ -122,7 +128,10 @@
             }
           }
         }
-      }
+      },
+      "required": [
+        "variants"
+      ]
     },
     "$comment": "Merge the variants with the base flag to build our typed flags",
     "booleanFlag": {

--- a/json/flagd-definitions.json
+++ b/json/flagd-definitions.json
@@ -76,8 +76,8 @@
             }
           },
           "default": {
-            "on": true,
-            "off": false
+            "true": true,
+            "false": false
           }
         }
       }

--- a/json/flagd-definitions.yaml
+++ b/json/flagd-definitions.yaml
@@ -53,8 +53,8 @@ $defs:
           ^.{1,}$:
             type: boolean
         default:
-          "on": true
-          "off": false
+          "true": true
+          "false": false
   stringVariants:
     type: object
     properties:

--- a/json/flagd-definitions.yaml
+++ b/json/flagd-definitions.yaml
@@ -34,6 +34,7 @@ $defs:
         enum:
           - ENABLED
           - DISABLED
+        default: ENABLED
       defaultVariant:
         description: The variant to serve if no dynamic targeting applies
         type: string
@@ -41,7 +42,6 @@ $defs:
         type: object
         description: JsonLogic expressions to be used for dynamic evaluation. The "context" is passed as the data. Rules must resolve one of the defined variants, or the "defaultVariant" will be used.
     required:
-      - state
       - defaultVariant
   booleanVariants:
     type: object
@@ -64,6 +64,8 @@ $defs:
         patternProperties:
           ^.{1,}$:
             type: string
+    required:
+      - variants
   numberVariants:
     type: object
     properties:
@@ -73,6 +75,8 @@ $defs:
         patternProperties:
           ^.{1,}$:
             type: number
+    required:
+      - variants
   objectVariants:
     type: object
     properties:
@@ -82,6 +86,8 @@ $defs:
         patternProperties:
           ^.{1,}$:
             type: object
+    required:
+      - variants
   $comment: Merge the variants with the base flag to build our typed flags
   booleanFlag:
     allOf:

--- a/json/test/negative/missing-variants.json
+++ b/json/test/negative/missing-variants.json
@@ -1,8 +1,0 @@
-{
-    "flags": {
-      "myBoolFlag": {
-        "state": "ENABLED",
-        "defaultVariant": "on"
-      }
-    }
-  }

--- a/json/test/positive/omitted-state.json
+++ b/json/test/positive/omitted-state.json
@@ -1,0 +1,11 @@
+{
+  "flags": {
+    "myBoolFlag": {
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "on"
+    }
+  }
+}

--- a/json/test/positive/omitted-variants.json
+++ b/json/test/positive/omitted-variants.json
@@ -1,0 +1,8 @@
+{
+  "flags": {
+    "myBoolFlag": {
+      "state": "ENABLED",
+      "defaultVariant": "on"
+    }
+  }
+}

--- a/json/test/positive/omitted-variants.json
+++ b/json/test/positive/omitted-variants.json
@@ -2,7 +2,7 @@
   "flags": {
     "myBoolFlag": {
       "state": "ENABLED",
-      "defaultVariant": "on"
+      "defaultVariant": "true"
     }
   }
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- removes state as required property (implementor should default to ENABLED)
- relaxed schema to allow variants of boolean flag to be null (implementor should set the variants to given default if not set)

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #80 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

