### PR TITLE
feat: add metadata endpoint

### DIFF
--- a/protobuf/flagd/sync/v1/sync.proto
+++ b/protobuf/flagd/sync/v1/sync.proto
@@ -59,8 +59,23 @@ message FetchAllFlagsResponse {
   string flag_configuration = 1;
 }
 
+// GetMetadataRequest is the request for retrieving metadata from the sync service
+message GetMetadataRequest {}
+
+// GetMetadataResponse contains metadata from the sync service
+message GetMetadataResponse {
+  repeated KeyValue metadata = 1;
+}
+
+// KeyValue represents a key/value pair
+message KeyValue {
+  string key = 1;
+  string value = 2;
+}
+
 // FlagService implements a server streaming to provide realtime flag configurations
 service FlagSyncService {
   rpc SyncFlags(SyncFlagsRequest) returns (stream SyncFlagsResponse) {}
   rpc FetchAllFlags(FetchAllFlagsRequest) returns (FetchAllFlagsResponse) {}
+  rpc GetMetadata(GetMetadataRequest) returns (GetMetadataResponse) {}
 }


### PR DESCRIPTION
This PR adds a new method and message definitions for retrieving metadata from a sync provider. What exactly the attributes of the metadata response are is up to the implementation of the sync service, as the response for the `GetMetadata` requests is a string map containing arbitrary keys. Examples for those attributes could be the name of the environment or the kubernetes cluster the service is running in