### PR TITLE
feat: add targeting schema, improve def. schema

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Validate Schema
-        run: go test -v ./json
+        run: make test
 
       # Ensure there is no diff when make gen-schema-json is run 
       - run: make gen-schema-json

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,9 @@ gen-rust: install-buf guard-GOPATH
 
 gen-schema-json: install-yq
 	yq eval -o=json json/flagd-definitions.yaml > json/flagd-definitions.json
+	yq eval -o=json json/targeting.yaml > json/targeting.json
 	
 ajv-validate-flagd-schema:
 	@if ! npm ls ajv-cli; then npm ci; fi
 	npx ajv compile -s json/flagd-definitions.json
+	npx ajv compile -s json/targeting.json

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,10 @@ gen-schema-json: install-yq
 	yq eval -o=json json/flagd-definitions.yaml > json/flagd-definitions.json
 	yq eval -o=json json/targeting.yaml > json/targeting.json
 	
+.PHONY: test
+test:
+	go test -v ./json
+
 ajv-validate-flagd-schema:
 	@if ! npm ls ajv-cli; then npm ci; fi
 	npx ajv compile -s json/targeting.json

--- a/Makefile
+++ b/Makefile
@@ -48,5 +48,6 @@ gen-schema-json: install-yq
 	
 ajv-validate-flagd-schema:
 	@if ! npm ls ajv-cli; then npm ci; fi
-	npx ajv compile -s json/flagd-definitions.json
 	npx ajv compile -s json/targeting.json
+# 	load the targeting json so flagd-definitions.json can reference it
+	npx ajv compile -r json/targeting.json -s json/flagd-definitions.json

--- a/json/examples/full.json
+++ b/json/examples/full.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../flagd-definitions.json",
   "flags": {
     "myBoolFlag": {
       "state": "ENABLED",
@@ -35,6 +36,244 @@
         }
       },
       "defaultVariant": "object1"
+    },
+    "fractional-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "clubs": "clubs",
+        "diamonds": "diamonds",
+        "hearts": "hearts",
+        "spades": "spades",
+        "wild": "wild"
+      },
+      "defaultVariant": "wild",
+      "targeting": {
+        "fractional": [
+          { "var": "user.name" },
+          ["clubs", 25],
+          ["diamonds", 25],
+          ["hearts", 25],
+          ["spades", 25]
+        ]
+      }
+    },
+    "shorthand-fractional-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "clubs": "clubs",
+        "diamonds": "diamonds",
+        "hearts": "hearts",
+        "spades": "spades",
+        "wild": "wild"
+      },
+      "defaultVariant": "wild",
+      "targeting": {
+        "fractional": [
+          ["clubs", 25],
+          ["diamonds", 25],
+          ["hearts", 25],
+          ["spades", 25]
+        ]
+      }
+    },
+    "starts-ends-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "prefix": "prefix",
+        "postfix": "postfix",
+        "none": "none"
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "if": [
+          {
+            "starts_with": [{ "var": "id" }, "abc"]
+          },
+          "prefix",
+          {
+            "if": [
+              {
+                "ends_with": [{ "var": "id" }, "xyz"]
+              },
+              "postfix",
+              {
+                "if": [
+                  {
+                    "ends_with": [{ "var": "id" }, 3]
+                  },
+                  "fail",
+                  "none"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "equal-greater-lesser-version-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "equal": "equal",
+        "greater": "greater",
+        "lesser": "lesser",
+        "none": "none"
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "if": [
+          {
+            "sem_ver": [{ "var": "version" }, "=", "2.0.0"]
+          },
+          "equal",
+          {
+            "if": [
+              {
+                "sem_ver": [{ "var": "version" }, ">", "2.0.0"]
+              },
+              "greater",
+              {
+                "if": [
+                  {
+                    "sem_ver": [{ "var": "version" }, "<", "2.0.0"]
+                  },
+                  "lesser",
+                  {
+                    "if": [
+                      {
+                        "sem_ver": [{ "var": "version" }, "=", "2.0.0.0"]
+                      },
+                      "fail",
+                      null
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "major-minor-version-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "minor": "minor",
+        "major": "major",
+        "none": "none"
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "if": [
+          {
+            "sem_ver": [{ "var": "version" }, "~", "3.0.0"]
+          },
+          "minor",
+          {
+            "if": [
+              {
+                "sem_ver": [{ "var": "version" }, "^", "3.0.0"]
+              },
+              "major",
+              "none"
+            ]
+          }
+        ]
+      }
+    },
+    "test-cat": {
+      "state": "ENABLED",
+      "variants": {
+        "minor": "minor",
+        "major": "major",
+        "none": "none"
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "cat": ["1", "@"]
+      }
+    },
+    "context-aware": {
+      "state": "ENABLED",
+      "variants": {
+        "internal": "INTERNAL",
+        "external": "EXTERNAL"
+      },
+      "defaultVariant": "external",
+      "targeting": {
+        "if": [
+          {
+            "and": [
+              {
+                "==": [
+                  {
+                    "var": ["fn"]
+                  },
+                  "Sulisław"
+                ]
+              },
+              {
+                "==": [
+                  {
+                    "var": ["ln"]
+                  },
+                  "Świętopełk"
+                ]
+              },
+              {
+                "==": [
+                  {
+                    "var": ["age"]
+                  },
+                  29
+                ]
+              },
+              {
+                "==": [
+                  {
+                    "var": ["customer"]
+                  },
+                  false
+                ]
+              }
+            ]
+          },
+          "internal",
+          "external"
+        ]
+      }
+    },
+    "timestamp-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "past": -1,
+        "future": 1,
+        "none": 0
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "if": [
+          {
+            ">": [{ "var": "$flagd.timestamp" }, { "var": "time" }]
+          },
+          "past",
+          {
+            "if": [
+              {
+                "<": [{ "var": "$flagd.timestamp" }, { "var": "time" }]
+              },
+              "future",
+              "none"
+            ]
+          }
+        ]
+      }
+    },
+    "wrong-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "one": "uno",
+        "two": "dos"
+      },
+      "defaultVariant": "one"
     }
   }
 }

--- a/json/flagd-definitions.json
+++ b/json/flagd-definitions.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://flagd.dev/schema/flagd-definitions.json",
+  "$id": "https://flagd.dev/schema/v0/flagd-definitions.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "flagd Flag Configuration",
   "description": "Defines flags for use in flagd, including typed variants and rules",

--- a/json/flagd-definitions.json
+++ b/json/flagd-definitions.json
@@ -61,7 +61,10 @@
           "title": "Flag State",
           "description": "Indicates whether the flag is functional. Disabled flags are treated as if they don't exist.",
           "type": "string",
-          "enum": ["ENABLED", "DISABLED"]
+          "enum": [
+            "ENABLED",
+            "DISABLED"
+          ]
         },
         "defaultVariant": {
           "title": "Default Variant",
@@ -72,7 +75,10 @@
           "$ref": "./targeting.json#/$defs/targeting"
         }
       },
-      "required": ["state", "defaultVariant"]
+      "required": [
+        "state",
+        "defaultVariant"
+      ]
     },
     "booleanVariants": {
       "type": "object",

--- a/json/flagd-definitions.json
+++ b/json/flagd-definitions.json
@@ -1,4 +1,5 @@
 {
+  "$id": "flagd.dev/schema/flagd-definitions.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "flagd Flag Configuration",
   "description": "Defines flags for use in flagd, including typed variants and rules",
@@ -12,8 +13,6 @@
       "additionalProperties": false,
       "patternProperties": {
         "^.{1,}$": {
-          "$comment": "'unevaluatedProperties': 'false' prevents additional props on a flag (ie: targetting)",
-          "unevaluatedProperties": false,
           "oneOf": [
             {
               "title": "Boolean flag",

--- a/json/flagd-definitions.json
+++ b/json/flagd-definitions.json
@@ -1,5 +1,5 @@
 {
-  "$id": "flagd.dev/schema/flagd-definitions.json",
+  "$id": "https://flagd.dev/schema/flagd-definitions.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "flagd Flag Configuration",
   "description": "Defines flags for use in flagd, including typed variants and rules",
@@ -46,7 +46,7 @@
       "patternProperties": {
         "^.{1,}$": {
           "$comment": "this relative ref means that targeting.json MUST be in the same dir, or available on the same HTTP path",
-          "$ref": "./targeting.json#/$defs/targeting"
+          "$ref": "https://flagd.dev/schema/targeting.json#/$defs/targeting"
         }
       }
     }
@@ -71,7 +71,7 @@
           "type": "string"
         },
         "targeting": {
-          "$ref": "./targeting.json#/$defs/targeting"
+          "$ref": "https://flagd.dev/schema/targeting.json#/$defs/targeting"
         }
       },
       "required": [

--- a/json/flagd-definitions.json
+++ b/json/flagd-definitions.json
@@ -91,8 +91,8 @@
             }
           },
           "default": {
-            "on": true,
-            "off": false
+            "true": true,
+            "false": false
           }
         }
       }

--- a/json/flagd-definitions.json
+++ b/json/flagd-definitions.json
@@ -5,64 +5,74 @@
   "type": "object",
   "properties": {
     "flags": {
+      "title": "Flags",
+      "description": "Top-level flags object. All flags are defined here.",
       "type": "object",
       "$comment": "flag objects are one of the 4 flag types defined in $defs",
       "additionalProperties": false,
       "patternProperties": {
         "^.{1,}$": {
+          "$comment": "'unevaluatedProperties': 'false' prevents additional props on a flag (ie: targetting)",
+          "unevaluatedProperties": false,
           "oneOf": [
             {
               "title": "Boolean flag",
-              "description": "A flag associated with boolean values",
+              "description": "A flag having boolean values.",
               "$ref": "#/$defs/booleanFlag"
             },
             {
               "title": "String flag",
-              "description": "A flag associated with string values",
+              "description": "A flag having string values.",
               "$ref": "#/$defs/stringFlag"
             },
             {
               "title": "Numeric flag",
-              "description": "A flag associated with numeric values",
+              "description": "A flag having numeric values.",
               "$ref": "#/$defs/numberFlag"
             },
             {
               "title": "Object flag",
-              "description": "A flag associated with arbitrary object values",
+              "description": "A flag having arbitrary object values.",
               "$ref": "#/$defs/objectFlag"
             }
           ]
+        }
+      }
+    },
+    "$evaluators": {
+      "title": "Evaluators",
+      "description": "Reusable targeting rules that can be referenced with \"$ref\": \"myRule\" in multiple flags.",
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^.{1,}$": {
+          "$comment": "this relative ref means that targeting.json MUST be in the same dir, or available on the same HTTP path",
+          "$ref": "./targeting.json#/$defs/targeting"
         }
       }
     }
   },
   "$defs": {
     "flag": {
-      "title": "Flag Base",
-      "description": "Base object for all flags",
+      "$comment": "base flag object; no title/description here, allows for better UX, keep it in the overrides",
       "type": "object",
       "properties": {
         "state": {
-          "description": "Indicates whether the flag is functional. Disabled flags are treated as if they don't exist",
+          "title": "Flag State",
+          "description": "Indicates whether the flag is functional. Disabled flags are treated as if they don't exist.",
           "type": "string",
-          "enum": [
-            "ENABLED",
-            "DISABLED"
-          ]
+          "enum": ["ENABLED", "DISABLED"]
         },
         "defaultVariant": {
-          "description": "The variant to serve if no dynamic targeting applies",
+          "title": "Default Variant",
+          "description": "The variant to serve if no dynamic targeting applies (including if the targeting returns null).",
           "type": "string"
         },
         "targeting": {
-          "type": "object",
-          "description": "JsonLogic expressions to be used for dynamic evaluation. The \"context\" is passed as the data. Rules must resolve one of the defined variants, or the \"defaultVariant\" will be used."
+          "$ref": "./targeting.json#/$defs/targeting"
         }
       },
-      "required": [
-        "state",
-        "defaultVariant"
-      ]
+      "required": ["state", "defaultVariant"]
     },
     "booleanVariants": {
       "type": "object",
@@ -124,7 +134,7 @@
         }
       }
     },
-    "$comment": "Merge the variants with the base flag to build our typed flags",
+    "$comment": "merge the variants with the base flag to build our typed flags",
     "booleanFlag": {
       "allOf": [
         {

--- a/json/flagd-definitions.json
+++ b/json/flagd-definitions.json
@@ -46,7 +46,7 @@
       "patternProperties": {
         "^.{1,}$": {
           "$comment": "this relative ref means that targeting.json MUST be in the same dir, or available on the same HTTP path",
-          "$ref": "https://flagd.dev/schema/targeting.json#/$defs/targeting"
+          "$ref": "./targeting.json#/$defs/targeting"
         }
       }
     }
@@ -71,7 +71,7 @@
           "type": "string"
         },
         "targeting": {
-          "$ref": "https://flagd.dev/schema/targeting.json#/$defs/targeting"
+          "$ref": "./targeting.json#/$defs/targeting"
         }
       },
       "required": [

--- a/json/flagd-definitions.yaml
+++ b/json/flagd-definitions.yaml
@@ -1,4 +1,4 @@
-$id: "https://flagd.dev/schema/flagd-definitions.json"
+$id: "https://flagd.dev/schema/v0/flagd-definitions.json"
 $schema: http://json-schema.org/draft-07/schema#
 title: flagd Flag Configuration
 description: Defines flags for use in flagd, including typed variants and rules

--- a/json/flagd-definitions.yaml
+++ b/json/flagd-definitions.yaml
@@ -70,8 +70,8 @@ properties:
           "^.{1,}$":
             type: boolean
         default:
-          'on': true
-          'off': false
+          'true': true
+          'false': false
   stringVariants:
     type: object
     properties:

--- a/json/flagd-definitions.yaml
+++ b/json/flagd-definitions.yaml
@@ -1,3 +1,4 @@
+$id: "flagd.dev/schema/flagd-definitions.json"
 $schema: http://json-schema.org/draft-07/schema#
 title: flagd Flag Configuration
 description: Defines flags for use in flagd, including typed variants and rules
@@ -7,13 +8,10 @@ properties:
     title: Flags
     description: Top-level flags object. All flags are defined here.
     type: object
-    "$comment": flag objects are one of the 4 flag types defined in $defs
+    $comment: flag objects are one of the 4 flag types defined in $defs
     additionalProperties: false
     patternProperties:
       "^.{1,}$":
-        "$comment": "'unevaluatedProperties': 'false' prevents additional props on
-          a flag (ie: targetting)"
-        unevaluatedProperties: false
         oneOf:
         - title: Boolean flag
           description: A flag having boolean values.
@@ -35,12 +33,12 @@ properties:
     additionalProperties: false
     patternProperties:
       "^.{1,}$":
-        "$comment": this relative ref means that targeting.json MUST be in the same
+        $comment: this relative ref means that targeting.json MUST be in the same
           dir, or available on the same HTTP path
         $ref: "./targeting.json#/$defs/targeting"
 "$defs":
   flag:
-    "$comment": base flag object; no title/description here, allows for better UX,
+    $comment: base flag object; no title/description here, allows for better UX,
       keep it in the overrides
     type: object
     properties:
@@ -101,7 +99,7 @@ properties:
         patternProperties:
           "^.{1,}$":
             type: object
-  "$comment": merge the variants with the base flag to build our typed flags
+  $comment: merge the variants with the base flag to build our typed flags
   booleanFlag:
     allOf:
     - $ref: "#/$defs/flag"

--- a/json/flagd-definitions.yaml
+++ b/json/flagd-definitions.yaml
@@ -4,45 +4,64 @@ description: Defines flags for use in flagd, including typed variants and rules
 type: object
 properties:
   flags:
+    title: Flags
+    description: Top-level flags object. All flags are defined here.
     type: object
-    $comment: flag objects are one of the 4 flag types defined in $defs
+    "$comment": flag objects are one of the 4 flag types defined in $defs
     additionalProperties: false
     patternProperties:
-      ^.{1,}$:
+      "^.{1,}$":
+        "$comment": "'unevaluatedProperties': 'false' prevents additional props on
+          a flag (ie: targetting)"
+        unevaluatedProperties: false
         oneOf:
-          - title: Boolean flag
-            description: A flag associated with boolean values
-            $ref: '#/$defs/booleanFlag'
-          - title: String flag
-            description: A flag associated with string values
-            $ref: '#/$defs/stringFlag'
-          - title: Numeric flag
-            description: A flag associated with numeric values
-            $ref: '#/$defs/numberFlag'
-          - title: Object flag
-            description: A flag associated with arbitrary object values
-            $ref: '#/$defs/objectFlag'
-$defs:
+        - title: Boolean flag
+          description: A flag having boolean values.
+          $ref: "#/$defs/booleanFlag"
+        - title: String flag
+          description: A flag having string values.
+          $ref: "#/$defs/stringFlag"
+        - title: Numeric flag
+          description: A flag having numeric values.
+          $ref: "#/$defs/numberFlag"
+        - title: Object flag
+          description: A flag having arbitrary object values.
+          $ref: "#/$defs/objectFlag"
+  "$evaluators":
+    title: Evaluators
+    description: 'Reusable targeting rules that can be referenced with "$ref": "myRule"
+      in multiple flags.'
+    type: object
+    additionalProperties: false
+    patternProperties:
+      "^.{1,}$":
+        "$comment": this relative ref means that targeting.json MUST be in the same
+          dir, or available on the same HTTP path
+        $ref: "./targeting.json#/$defs/targeting"
+"$defs":
   flag:
-    title: Flag Base
-    description: Base object for all flags
+    "$comment": base flag object; no title/description here, allows for better UX,
+      keep it in the overrides
     type: object
     properties:
       state:
-        description: Indicates whether the flag is functional. Disabled flags are treated as if they don't exist
+        title: Flag State
+        description: Indicates whether the flag is functional. Disabled flags are
+          treated as if they don't exist.
         type: string
         enum:
-          - ENABLED
-          - DISABLED
+        - ENABLED
+        - DISABLED
       defaultVariant:
-        description: The variant to serve if no dynamic targeting applies
+        title: Default Variant
+        description: The variant to serve if no dynamic targeting applies (including
+          if the targeting returns null).
         type: string
       targeting:
-        type: object
-        description: JsonLogic expressions to be used for dynamic evaluation. The "context" is passed as the data. Rules must resolve one of the defined variants, or the "defaultVariant" will be used.
+        $ref: "./targeting.json#/$defs/targeting"
     required:
-      - state
-      - defaultVariant
+    - state
+    - defaultVariant
   booleanVariants:
     type: object
     properties:
@@ -50,11 +69,11 @@ $defs:
         type: object
         additionalProperties: false
         patternProperties:
-          ^.{1,}$:
+          "^.{1,}$":
             type: boolean
         default:
-          "on": true
-          "off": false
+          'on': true
+          'off': false
   stringVariants:
     type: object
     properties:
@@ -62,7 +81,7 @@ $defs:
         type: object
         additionalProperties: false
         patternProperties:
-          ^.{1,}$:
+          "^.{1,}$":
             type: string
   numberVariants:
     type: object
@@ -71,7 +90,7 @@ $defs:
         type: object
         additionalProperties: false
         patternProperties:
-          ^.{1,}$:
+          "^.{1,}$":
             type: number
   objectVariants:
     type: object
@@ -80,22 +99,22 @@ $defs:
         type: object
         additionalProperties: false
         patternProperties:
-          ^.{1,}$:
+          "^.{1,}$":
             type: object
-  $comment: Merge the variants with the base flag to build our typed flags
+  "$comment": merge the variants with the base flag to build our typed flags
   booleanFlag:
     allOf:
-      - $ref: '#/$defs/flag'
-      - $ref: '#/$defs/booleanVariants'
+    - $ref: "#/$defs/flag"
+    - $ref: "#/$defs/booleanVariants"
   stringFlag:
     allOf:
-      - $ref: '#/$defs/flag'
-      - $ref: '#/$defs/stringVariants'
+    - $ref: "#/$defs/flag"
+    - $ref: "#/$defs/stringVariants"
   numberFlag:
     allOf:
-      - $ref: '#/$defs/flag'
-      - $ref: '#/$defs/numberVariants'
+    - $ref: "#/$defs/flag"
+    - $ref: "#/$defs/numberVariants"
   objectFlag:
     allOf:
-      - $ref: '#/$defs/flag'
-      - $ref: '#/$defs/objectVariants'
+    - $ref: "#/$defs/flag"
+    - $ref: "#/$defs/objectVariants"

--- a/json/flagd-definitions.yaml
+++ b/json/flagd-definitions.yaml
@@ -35,7 +35,7 @@ properties:
       "^.{1,}$":
         $comment: this relative ref means that targeting.json MUST be in the same
           dir, or available on the same HTTP path
-        $ref: "https://flagd.dev/schema/targeting.json#/$defs/targeting"
+        $ref: "./targeting.json#/$defs/targeting"
 "$defs":
   flag:
     $comment: base flag object; no title/description here, allows for better UX,
@@ -56,7 +56,7 @@ properties:
           if the targeting returns null).
         type: string
       targeting:
-        $ref: "https://flagd.dev/schema/targeting.json#/$defs/targeting"
+        $ref: "./targeting.json#/$defs/targeting"
     required:
     - state
     - defaultVariant

--- a/json/flagd-definitions.yaml
+++ b/json/flagd-definitions.yaml
@@ -1,4 +1,4 @@
-$id: "flagd.dev/schema/flagd-definitions.json"
+$id: "https://flagd.dev/schema/flagd-definitions.json"
 $schema: http://json-schema.org/draft-07/schema#
 title: flagd Flag Configuration
 description: Defines flags for use in flagd, including typed variants and rules
@@ -25,7 +25,7 @@ properties:
         - title: Object flag
           description: A flag having arbitrary object values.
           $ref: "#/$defs/objectFlag"
-  "$evaluators":
+  $evaluators:
     title: Evaluators
     description: 'Reusable targeting rules that can be referenced with "$ref": "myRule"
       in multiple flags.'
@@ -35,7 +35,7 @@ properties:
       "^.{1,}$":
         $comment: this relative ref means that targeting.json MUST be in the same
           dir, or available on the same HTTP path
-        $ref: "./targeting.json#/$defs/targeting"
+        $ref: "https://flagd.dev/schema/targeting.json#/$defs/targeting"
 "$defs":
   flag:
     $comment: base flag object; no title/description here, allows for better UX,
@@ -56,7 +56,7 @@ properties:
           if the targeting returns null).
         type: string
       targeting:
-        $ref: "./targeting.json#/$defs/targeting"
+        $ref: "https://flagd.dev/schema/targeting.json#/$defs/targeting"
     required:
     - state
     - defaultVariant

--- a/json/flagd_definitions.go
+++ b/json/flagd_definitions.go
@@ -4,3 +4,6 @@ import _ "embed"
 
 //go:embed flagd-definitions.json
 var FlagdDefinitions string
+
+//go:embed targeting.json
+var Targeting string

--- a/json/flagd_definitions_test.go
+++ b/json/flagd_definitions_test.go
@@ -18,8 +18,6 @@ var s *gojsonschema.Schema
 
 func init() {
 	schemaLoader = gojsonschema.NewSchemaLoader()
-	//gojsonschema.NewStringLoader(flagd_definitions.FlagdDefinitions)
-	//schemaLoader.AddSchemas()
 	schemaLoader.AddSchemas(gojsonschema.NewStringLoader(flagd_definitions.Targeting))
 	var err error
 	s, err = schemaLoader.Compile(gojsonschema.NewStringLoader(flagd_definitions.FlagdDefinitions))

--- a/json/flagd_definitions_test.go
+++ b/json/flagd_definitions_test.go
@@ -2,19 +2,31 @@ package flagd_definitions_test
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	flagd_definitions "github.com/open-feature/schemas/json"
+
 	"github.com/xeipuuv/gojsonschema"
 )
 
-var schemaLoader gojsonschema.JSONLoader
+var schemaLoader *gojsonschema.SchemaLoader
+var s *gojsonschema.Schema
 
 func init() {
-	schemaLoader = gojsonschema.NewStringLoader(flagd_definitions.FlagdDefinitions)
+	schemaLoader = gojsonschema.NewSchemaLoader()
+	//gojsonschema.NewStringLoader(flagd_definitions.FlagdDefinitions)
+	//schemaLoader.AddSchemas()
+	schemaLoader.AddSchemas(gojsonschema.NewStringLoader(flagd_definitions.Targeting))
+	var err error
+	s, err = schemaLoader.Compile(gojsonschema.NewStringLoader(flagd_definitions.FlagdDefinitions))
+	if err != nil {
+		s := fmt.Errorf("err: %v", err)
+		log.Fatal(s)
+	}
 }
 
 func TestPositiveParsing(t *testing.T) {
@@ -46,7 +58,8 @@ func walkPath(shouldPass bool, root string) error {
 		}
 
 		flagStringLoader := gojsonschema.NewStringLoader(string(file))
-		p, err := gojsonschema.Validate(schemaLoader, flagStringLoader)
+
+		p, err := s.Validate(flagStringLoader)
 		if err != nil {
 			return err
 		}

--- a/json/flagd_definitions_test.go
+++ b/json/flagd_definitions_test.go
@@ -13,17 +13,16 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 )
 
-var schemaLoader *gojsonschema.SchemaLoader
-var s *gojsonschema.Schema
+var compiledSchema *gojsonschema.Schema
 
 func init() {
-	schemaLoader = gojsonschema.NewSchemaLoader()
+	schemaLoader := gojsonschema.NewSchemaLoader()
 	schemaLoader.AddSchemas(gojsonschema.NewStringLoader(flagd_definitions.Targeting))
 	var err error
-	s, err = schemaLoader.Compile(gojsonschema.NewStringLoader(flagd_definitions.FlagdDefinitions))
+	compiledSchema, err = schemaLoader.Compile(gojsonschema.NewStringLoader(flagd_definitions.FlagdDefinitions))
 	if err != nil {
-		s := fmt.Errorf("err: %v", err)
-		log.Fatal(s)
+		message := fmt.Errorf("err: %v", err)
+		log.Fatal(message)
 	}
 }
 
@@ -57,7 +56,7 @@ func walkPath(shouldPass bool, root string) error {
 
 		flagStringLoader := gojsonschema.NewStringLoader(string(file))
 
-		p, err := s.Validate(flagStringLoader)
+		p, err := compiledSchema.Validate(flagStringLoader)
 		if err != nil {
 			return err
 		}

--- a/json/targeting.json
+++ b/json/targeting.json
@@ -55,7 +55,7 @@
             },
             {
               "type": "string",
-              "pattern": "^(?!\\$flagd\\.).+"
+              "pattern": "^(?!\\$flagd.).*$"
             },
             {
               "type": "array",

--- a/json/targeting.json
+++ b/json/targeting.json
@@ -50,7 +50,7 @@
           "anyOf": [
             {
               "type": "string",
-              "description": "flagd automatically injects \"$lagd.timestamp\" (unix epoch) and \"$lagd.flagKey\" (the key of the flag in evaluation) into the context.",
+              "description": "flagd automatically injects \"$flagd.timestamp\" (unix epoch) and \"$flagd.flagKey\" (the key of the flag in evaluation) into the context.",
               "pattern": "^\\$flagd\\.((timestamp)|(flagKey))$"
             },
             {

--- a/json/targeting.json
+++ b/json/targeting.json
@@ -54,8 +54,12 @@
               "pattern": "^\\$flagd\\.((timestamp)|(flagKey))$"
             },
             {
-              "type": "string",
-              "pattern": "^(?!\\$flagd.).*$"
+              "not": {
+                "$comment": "this is a negated (not) match of \"$flagd.{some-key}\", which is faster and more compatible that a negative lookahead regex",
+                "type": "string",
+                "description": "flagd automatically injects \"$flagd.timestamp\" (unix epoch) and \"$flagd.flagKey\" (the key of the flag in evaluation) into the context.",
+                "pattern": "^\\$flagd\\..*$"
+              }
             },
             {
               "type": "array",
@@ -513,7 +517,7 @@
       ]
     },
     "anyRule": {
-      "oneOf": [
+      "anyOf": [
         {
           "$ref": "#/$defs/varRule"
         },

--- a/json/targeting.json
+++ b/json/targeting.json
@@ -239,7 +239,7 @@
     },
     "associativeRule": {
       "title": "Mathematically Associative Operation",
-      "description": "Pperation applicable to 2 or more parameters.",
+      "description": "Operation applicable to 2 or more parameters.",
       "type": "object",
       "additionalProperties": false,
       "properties": {

--- a/json/targeting.json
+++ b/json/targeting.json
@@ -58,7 +58,14 @@
             },
             {
               "type": "array",
-              "items": [{ "type": "string" }, { "type": {} }]
+              "items": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": {}
+                }
+              ]
             }
           ]
         }
@@ -72,7 +79,9 @@
       "properties": {
         "missing": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -85,10 +94,14 @@
         "missing_some": {
           "type": "array",
           "items": [
-            { "type": "number" },
+            {
+              "type": "number"
+            },
             {
               "type": "array",
-              "items": { "type": "string" }
+              "items": {
+                "type": "string"
+              }
             }
           ]
         }
@@ -103,7 +116,6 @@
         "if": {
           "title": "If Operator",
           "description": "The if statement takes 3 arguments: a condition (if), what to do if it’s true (then), and what to do if it’s false (else). Note that the form accepting more than 3 arguments (if/else) is not supported in flagd; use nesting instead.",
-
           "type": "array",
           "items": {
             "$ref": "#/$defs/args"
@@ -370,7 +382,16 @@
             },
             {
               "description": "Range specifiers: \"=\", \"!=\", \">\", \"<\", \">=\", \"<=\", \"~\" (match minor version), \"^\" (match major version).",
-              "enum": ["=", "!=", ">", "<", ">=", "<=", "~", "^"]
+              "enum": [
+                "=",
+                "!=",
+                ">",
+                "<",
+                ">=",
+                "<=",
+                "~",
+                "^"
+              ]
             },
             {
               "oneOf": [

--- a/json/targeting.json
+++ b/json/targeting.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://flagd.dev/schema/targeting.json",
+  "$id": "https://flagd.dev/schema/v0/targeting.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "flagd Targeting",
   "description": "Defines targeting logic for flagd; a extension of JSONLogic, including purpose-built feature-flagging operations.",
@@ -137,7 +137,7 @@
           "title": "If Operator",
           "description": "The if statement takes 3 arguments: a condition (if), what to do if its true (then), and what to do if its false (else). Note that the form accepting more than 3 arguments (if/else) is not supported in flagd; use nesting instead.",
           "type": "array",
-          "minItems": 3,
+          "minItems": 2,
           "maxItems": 3,
           "items": {
             "$ref": "#/$defs/args"

--- a/json/targeting.json
+++ b/json/targeting.json
@@ -1,4 +1,5 @@
 {
+  "$id": "flagd.dev/schema/targeting.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "flagd Targeting",
   "description": "Defines targeting logic for flagd; a extension of JSONLogic, including purpose-built feature-flagging operations.",
@@ -58,14 +59,29 @@
             },
             {
               "type": "array",
+              "$comment": "this is to support the form of var with a default... there seems to be a bug here, where ajv gives a warning (not an error) because maxItems doesn't equal the number of entries in items, though this is valid in this case",
+              "minItems": 1,
               "items": [
                 {
                   "type": "string"
-                },
-                {
-                  "type": {}
                 }
-              ]
+              ],
+              "additionalItems": {
+                "anyOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              }
             }
           ]
         }
@@ -92,6 +108,8 @@
       "additionalProperties": false,
       "properties": {
         "missing_some": {
+          "minItems": 2,
+          "maxItems": 2,
           "type": "array",
           "items": [
             {
@@ -110,13 +128,13 @@
     "ifRule": {
       "type": "object",
       "additionalProperties": false,
-      "minItems": 3,
-      "maxItems": 3,
       "properties": {
         "if": {
           "title": "If Operator",
-          "description": "The if statement takes 3 arguments: a condition (if), what to do if it’s true (then), and what to do if it’s false (else). Note that the form accepting more than 3 arguments (if/else) is not supported in flagd; use nesting instead.",
+          "description": "The if statement takes 3 arguments: a condition (if), what to do if its true (then), and what to do if its false (else). Note that the form accepting more than 3 arguments (if/else) is not supported in flagd; use nesting instead.",
           "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
           "items": {
             "$ref": "#/$defs/args"
           }
@@ -281,6 +299,7 @@
       }
     },
     "variadicRule": {
+      "$comment": "note < and <= can be used with up to 3 ops (between)",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -294,7 +313,6 @@
           "description": "Simple boolean test, with 1 or more arguments. At a more sophisticated level, \"and\" returns the first falsy argument, or the last argument.",
           "$ref": "#/$defs/variadicOp"
         },
-        "$comment": "< and <= can be used with up to 3 ops (between)",
         "<": {
           "title": "Less-Than/Between Operation. Can be used to test that one value is between two others.",
           "description": "",
@@ -369,6 +387,7 @@
           "description": "Attribute matches a semantic version condition. Accepts \"npm-style\" range specifiers: \"=\", \"!=\", \">\", \"<\", \">=\", \"<=\", \"~\" (match minor version), \"^\" (match major version).",
           "type": "array",
           "minItems": 3,
+          "maxItems": 3,
           "items": [
             {
               "oneOf": [
@@ -417,20 +436,27 @@
         {
           "description": "If this bucket is randomly selected, this string is used to as a key to retrieve the associated value from the \"variants\" object.",
           "type": "string"
+        },
+        {
+          "description": "Weighted distribution for this variant key (must sum to 100).",
+          "type": "number"
         }
-      ],
-      "additionalItems": {
-        "description": "Weighted distribution for this variant key (must sum to 100).",
-        "type": "number"
-      }
+      ]
     },
     "fractionalOp": {
       "type": "array",
       "minItems": 3,
+      "$comment": "there seems to be a bug here, where ajv gives a warning (not an error) because maxItems doesn't equal the number of entries in items, though this is valid in this case",
       "items": [
         {
           "description": "Bucketing value used in pseudorandom assignment; should be unique and stable for each subject of flag evaluation. Defaults to a concatenation of the flagKey and targetingKey.",
           "$ref": "#/$defs/varRule"
+        },
+        {
+          "$ref": "#/$defs/fractionalWeightArg"
+        },
+        {
+          "$ref": "#/$defs/fractionalWeightArg"
         }
       ],
       "additionalItems": {

--- a/json/targeting.json
+++ b/json/targeting.json
@@ -1,0 +1,506 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "flagd Targeting",
+  "description": "Defines targeting logic for flagd; a extension of JSONLogic, including purpose-built feature-flagging operations.",
+  "type": "object",
+  "$defs": {
+    "targeting": {
+      "title": "Targeting",
+      "description": "An expression returning a value which is coerced to a string to be used as a targeting key, or null (to fall back to defaultVariant). If targeting returns a value which is not a variant key, it's considered an error.",
+      "anyOf": [
+        {
+          "$comment": "we need this to support empty targeting",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        {
+          "$ref": "#/$defs/anyRule"
+        }
+      ]
+    },
+    "primitive": {
+      "oneOf": [
+        {
+          "description": "When returned from rules, a null value \"exits\", the targeting, and the \"defaultValue\" is returned, with the reason indicating the targeting did not match.",
+          "type": "null"
+        },
+        {
+          "description": "When returned from rules, booleans are converted to strings (\"true\"/\"false\"), and used to as keys to retrieve the associated value from the \"variants\" object. Be sure that the returned string is present as a key in the variants!",
+          "type": "boolean"
+        },
+        {
+          "description": "When returned from rules, the behavior of numbers is not defined.",
+          "type": "number"
+        },
+        {
+          "description": "When returned from rules, strings are used to as keys to retrieve the associated value from the \"variants\" object. Be sure that the returned string is present as a key in the variants!.",
+          "type": "string"
+        }
+      ]
+    },
+    "varRule": {
+      "title": "Var Operation",
+      "description": "Retrieve data from the provided data object.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "var": {
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "flagd automatically injects \"$lagd.timestamp\" (unix epoch) and \"$lagd.flagKey\" (the key of the flag in evaluation) into the context.",
+              "pattern": "^\\$flagd\\.((timestamp)|(flagKey))$"
+            },
+            {
+              "type": "string",
+              "pattern": "^(?!\\$flagd\\.).+"
+            },
+            {
+              "type": "array",
+              "items": [{ "type": "string" }, { "type": {} }]
+            }
+          ]
+        }
+      }
+    },
+    "missingRule": {
+      "title": "Missing Operation",
+      "description": "Takes an array of data keys to search for (same format as var). Returns an array of any keys that are missing from the data object, or an empty array.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "missing": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "missingSomeRule": {
+      "title": "Missing-Some Operation",
+      "description": "Takes a minimum number of data keys that are required, and an array of keys to search for (same format as var or missing). Returns an empty array if the minimum is met, or an array of the missing keys otherwise.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "missing_some": {
+          "type": "array",
+          "items": [
+            { "type": "number" },
+            {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          ]
+        }
+      }
+    },
+    "ifRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "minItems": 3,
+      "maxItems": 3,
+      "properties": {
+        "if": {
+          "title": "If Operator",
+          "description": "The if statement takes 3 arguments: a condition (if), what to do if it’s true (then), and what to do if it’s false (else). Note that the form accepting more than 3 arguments (if/else) is not supported in flagd; use nesting instead.",
+
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/args"
+          }
+        }
+      }
+    },
+    "binaryOp": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {
+        "$ref": "#/$defs/args"
+      }
+    },
+    "binaryRule": {
+      "title": "Binary Operation",
+      "description": "Any primitive JSONLogic operation with 2 operands.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "==": {
+          "title": "Lose Equality Operation",
+          "description": "Tests equality, with type coercion. Requires two arguments.",
+          "$ref": "#/$defs/binaryOp"
+        },
+        "===": {
+          "title": "Strict Equality Operation",
+          "description": "Tests strict equality. Requires two arguments.",
+          "$ref": "#/$defs/binaryOp"
+        },
+        "!=": {
+          "title": "Lose Inequality Operation",
+          "description": "Tests not-equal, with type coercion.",
+          "$ref": "#/$defs/binaryOp"
+        },
+        "!==": {
+          "title": "Strict Inequality Operation",
+          "description": "Tests strict not-equal.",
+          "$ref": "#/$defs/binaryOp"
+        },
+        ">": {
+          "title": "Greater-Than Operation",
+          "$ref": "#/$defs/binaryOp"
+        },
+        ">=": {
+          "title": "Greater-Than-Or-Equal-To Operation",
+          "$ref": "#/$defs/binaryOp"
+        },
+        "%": {
+          "title": "Modulo Operation",
+          "description": "Finds the remainder after the first argument is divided by the second argument.",
+          "$ref": "#/$defs/binaryOp"
+        },
+        "map": {
+          "title": "Map Operation",
+          "description": "Perform an action on every member of an array. Note, that inside the logic being used to map, var operations are relative to the array element being worked on.",
+          "$ref": "#/$defs/binaryOp"
+        },
+        "reduce": {
+          "title": "Reduce Operation",
+          "description": "Combine all the elements in an array into a single value, like adding up a list of numbers. Note, that inside the logic being used to reduce, var operations only have access to an object with a \"current\" and a \"accumulator\".",
+          "$ref": "#/$defs/binaryOp"
+        },
+        "filter": {
+          "title": "Filter Operation",
+          "description": "Keep only elements of the array that pass a test. Note, that inside the logic being used to filter, var operations are relative to the array element being worked on.",
+          "$ref": "#/$defs/binaryOp"
+        },
+        "all": {
+          "title": "All Operation",
+          "description": "Perform a test on each member of that array, returning true if all pass. Inside the test code, var operations are relative to the array element being tested.",
+          "$ref": "#/$defs/binaryOp"
+        },
+        "none": {
+          "title": "None Operation",
+          "description": "Perform a test on each member of that array, returning true if none pass. Inside the test code, var operations are relative to the array element being tested.",
+          "$ref": "#/$defs/binaryOp"
+        },
+        "some": {
+          "title": "Some Operation",
+          "description": "Perform a test on each member of that array, returning true if some pass. Inside the test code, var operations are relative to the array element being tested.",
+          "$ref": "#/$defs/binaryOp"
+        },
+        "in": {
+          "title": "In Operation",
+          "description": "If the second argument is an array, tests that the first argument is a member of the array.",
+          "$ref": "#/$defs/binaryOp"
+        },
+        "substr": {
+          "title": "Substring Operation",
+          "description": "Get a portion of a string, given a positive start position as an index (indexes of course start at zero).",
+          "$ref": "#/$defs/binaryOp"
+        }
+      }
+    },
+    "associativeOp": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "$ref": "#/$defs/args"
+      }
+    },
+    "associativeRule": {
+      "title": "Mathematically Associative Operation",
+      "description": "Pperation applicable to 2 or more parameters.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "+": {
+          "title": "Addition Operation",
+          "description": "Addition; associative, will accept and unlimited amount of arguments.",
+          "$ref": "#/$defs/associativeOp"
+        },
+        "*": {
+          "title": "Multiplication Operation",
+          "description": "Multiplication; associative, will accept and unlimited amount of arguments.",
+          "$ref": "#/$defs/associativeOp"
+        }
+      }
+    },
+    "unaryOp": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1,
+      "items": {
+        "$ref": "#/$defs/args"
+      }
+    },
+    "unaryRule": {
+      "title": "Unary Operation",
+      "description": "Any primitive JSONLogic operation with 1 operands.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "!": {
+          "title": "Negation Operation",
+          "description": "Logical negation (“not”). Takes just one argument.",
+          "$ref": "#/$defs/unaryOp"
+        },
+        "!!": {
+          "title": "Double Negation Operation",
+          "description": "Double negation, or 'cast to a boolean'. Takes a single argument.",
+          "$ref": "#/$defs/unaryOp"
+        },
+        "max": {
+          "title": "Maximum Operation",
+          "description": "Return the maximum from a list of values.",
+          "$ref": "#/$defs/unaryOp"
+        },
+        "min": {
+          "title": "Minimum Operation",
+          "description": "Return the minimum from a list of values.",
+          "$ref": "#/$defs/unaryOp"
+        }
+      }
+    },
+    "variadicOp": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/args"
+      }
+    },
+    "variadicRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "or": {
+          "title": "Or Operation",
+          "description": "Simple boolean test, with 1 or more arguments. At a more sophisticated level, \"or\" returns the first truthy argument, or the last argument.",
+          "$ref": "#/$defs/variadicOp"
+        },
+        "and": {
+          "title": "",
+          "description": "Simple boolean test, with 1 or more arguments. At a more sophisticated level, \"and\" returns the first falsy argument, or the last argument.",
+          "$ref": "#/$defs/variadicOp"
+        },
+        "$comment": "< and <= can be used with up to 3 ops (between)",
+        "<": {
+          "title": "Less-Than/Between Operation. Can be used to test that one value is between two others.",
+          "description": "",
+          "$ref": "#/$defs/variadicOp"
+        },
+        "<=": {
+          "title": "Less-Than-Or-Equal-To/Between Operation. Can be used to test that one value is between two others.",
+          "description": "",
+          "$ref": "#/$defs/variadicOp"
+        },
+        "-": {
+          "title": "Subtraction Operation",
+          "$ref": "#/$defs/variadicOp"
+        },
+        "merge": {
+          "title": "Subtraction Operation",
+          "description": "Takes one or more arrays, and merges them into one array. If arguments aren't arrays, they get cast to arrays.",
+          "$ref": "#/$defs/variadicOp"
+        },
+        "cat": {
+          "title": "Concatenate Operation",
+          "description": "Concatenate all the supplied arguments. Note that this is not a join or implode operation, there is no “glue” string.",
+          "$ref": "#/$defs/variadicOp"
+        }
+      }
+    },
+    "stringCompareArg": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/anyRule"
+        }
+      ]
+    },
+    "stringCompareArgs": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "$ref": "#/$defs/stringCompareArg"
+      }
+    },
+    "stringCompareRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "starts_with": {
+          "title": "Starts-With Operation",
+          "description": "Attribute starts with the specified value.",
+          "$ref": "#/$defs/stringCompareArgs"
+        },
+        "ends_with": {
+          "title": "Ends-With Operation",
+          "description": "Attribute ends with the specified value.",
+          "$ref": "#/$defs/stringCompareArgs"
+        }
+      }
+    },
+    "semVerString": {
+      "title": "Semantic Version String",
+      "description": "A string representing a valid semantic version expression as per https://semver.org/.",
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+    },
+    "ruleSemVer": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sem_ver": {
+          "title": "Semantic Version Operation",
+          "description": "Attribute matches a semantic version condition. Accepts \"npm-style\" range specifiers: \"=\", \"!=\", \">\", \"<\", \">=\", \"<=\", \"~\" (match minor version), \"^\" (match major version).",
+          "type": "array",
+          "minItems": 3,
+          "items": [
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/semVerString"
+                },
+                {
+                  "$ref": "#/$defs/varRule"
+                }
+              ]
+            },
+            {
+              "description": "Range specifiers: \"=\", \"!=\", \">\", \"<\", \">=\", \"<=\", \"~\" (match minor version), \"^\" (match major version).",
+              "enum": ["=", "!=", ">", "<", ">=", "<=", "~", "^"]
+            },
+            {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/semVerString"
+                },
+                {
+                  "$ref": "#/$defs/varRule"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "fractionalWeightArg": {
+      "$comment": "if we remove the \"some to 100\" restriction, update the descriptions below!",
+      "description": "Distribution for all possible variants, with their associated weighting out of 100.",
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": [
+        {
+          "description": "If this bucket is randomly selected, this string is used to as a key to retrieve the associated value from the \"variants\" object.",
+          "type": "string"
+        }
+      ],
+      "additionalItems": {
+        "description": "Weighted distribution for this variant key (must sum to 100).",
+        "type": "number"
+      }
+    },
+    "fractionalOp": {
+      "type": "array",
+      "minItems": 3,
+      "items": [
+        {
+          "description": "Bucketing value used in pseudorandom assignment; should be unique and stable for each subject of flag evaluation. Defaults to a concatenation of the flagKey and targetingKey.",
+          "$ref": "#/$defs/varRule"
+        }
+      ],
+      "additionalItems": {
+        "$ref": "#/$defs/fractionalWeightArg"
+      }
+    },
+    "fractionalShorthandOp": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "$ref": "#/$defs/fractionalWeightArg"
+      }
+    },
+    "fractionalRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "fractional": {
+          "title": "Fractional Operation",
+          "description": "Deterministic, pseudorandom fractional distribution.",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/fractionalOp"
+            },
+            {
+              "$ref": "#/$defs/fractionalShorthandOp"
+            }
+          ]
+        }
+      }
+    },
+    "reference": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "title": "Reference",
+          "description": "A reference to another entity, used for $evaluators (shared rules).",
+          "type": "string"
+        }
+      }
+    },
+    "args": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/reference"
+        },
+        {
+          "$ref": "#/$defs/anyRule"
+        },
+        {
+          "$ref": "#/$defs/primitive"
+        }
+      ]
+    },
+    "anyRule": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/varRule"
+        },
+        {
+          "$ref": "#/$defs/missingRule"
+        },
+        {
+          "$ref": "#/$defs/missingSomeRule"
+        },
+        {
+          "$ref": "#/$defs/ifRule"
+        },
+        {
+          "$ref": "#/$defs/binaryRule"
+        },
+        {
+          "$ref": "#/$defs/associativeRule"
+        },
+        {
+          "$ref": "#/$defs/unaryRule"
+        },
+        {
+          "$ref": "#/$defs/variadicRule"
+        },
+        {
+          "$ref": "#/$defs/stringCompareRule"
+        },
+        {
+          "$ref": "#/$defs/ruleSemVer"
+        },
+        {
+          "$ref": "#/$defs/fractionalRule"
+        }
+      ]
+    }
+  }
+}

--- a/json/targeting.json
+++ b/json/targeting.json
@@ -1,5 +1,5 @@
 {
-  "$id": "flagd.dev/schema/targeting.json",
+  "$id": "https://flagd.dev/schema/targeting.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "flagd Targeting",
   "description": "Defines targeting logic for flagd; a extension of JSONLogic, including purpose-built feature-flagging operations.",

--- a/json/targeting.json
+++ b/json/targeting.json
@@ -356,6 +356,7 @@
     "stringCompareArgs": {
       "type": "array",
       "minItems": 2,
+      "maxItems": 2,
       "items": {
         "$ref": "#/$defs/stringCompareArg"
       }
@@ -366,12 +367,12 @@
       "properties": {
         "starts_with": {
           "title": "Starts-With Operation",
-          "description": "Attribute starts with the specified value.",
+          "description": "The string attribute starts with the specified string value.",
           "$ref": "#/$defs/stringCompareArgs"
         },
         "ends_with": {
           "title": "Ends-With Operation",
-          "description": "Attribute ends with the specified value.",
+          "description": "The string attribute ends with the specified string value.",
           "$ref": "#/$defs/stringCompareArgs"
         }
       }

--- a/json/targeting.yaml
+++ b/json/targeting.yaml
@@ -1,4 +1,4 @@
-$id: "flagd.dev/schema/targeting.json"
+$id: "https://flagd.dev/schema/targeting.json"
 $schema: http://json-schema.org/draft-07/schema#
 title: flagd Targeting
 description: Defines targeting logic for flagd; a extension of JSONLogic, including

--- a/json/targeting.yaml
+++ b/json/targeting.yaml
@@ -41,8 +41,8 @@ type: object
       var:
         anyOf:
         - type: string
-          description: flagd automatically injects "$lagd.timestamp" (unix epoch)
-            and "$lagd.flagKey" (the key of the flag in evaluation) into the context.
+          description: flagd automatically injects "$flagd.timestamp" (unix epoch)
+            and "$flagd.flagKey" (the key of the flag in evaluation) into the context.
           pattern: "^\\$flagd\\.((timestamp)|(flagKey))$"
         - type: string
           pattern: "^(?!\\$flagd\\.).+"
@@ -196,7 +196,7 @@ type: object
       $ref: "#/$defs/args"
   associativeRule:
     title: Mathematically Associative Operation
-    description: Pperation applicable to 2 or more parameters.
+    description: Operation applicable to 2 or more parameters.
     type: object
     additionalProperties: false
     properties:

--- a/json/targeting.yaml
+++ b/json/targeting.yaml
@@ -44,8 +44,12 @@ type: object
           description: flagd automatically injects "$flagd.timestamp" (unix epoch)
             and "$flagd.flagKey" (the key of the flag in evaluation) into the context.
           pattern: "^\\$flagd\\.((timestamp)|(flagKey))$"
-        - type: string
-          pattern: "^(?!\\$flagd\\.).+"
+        - not:
+            $comment: this is a negated (not) match of "$flagd.{some-key}", which is faster and more compatible that a negative lookahead regex
+            type: string
+            description: flagd automatically injects "$flagd.timestamp" (unix epoch) and "$flagd.flagKey"
+              (the key of the flag in evaluation) into the context.
+            pattern: "^\\$flagd\\..*$"
         - type: array
           $comment: this is to support the form of var with a default... there seems to be a bug here, where ajv gives a warning (not an error) because maxItems doesn't equal the number of entries in items, though this is valid in this case
           minItems: 1
@@ -393,7 +397,7 @@ type: object
     - $ref: "#/$defs/anyRule"
     - $ref: "#/$defs/primitive"
   anyRule:
-    oneOf:
+    anyOf:
     - $ref: "#/$defs/varRule"
     - $ref: "#/$defs/missingRule"
     - $ref: "#/$defs/missingSomeRule"

--- a/json/targeting.yaml
+++ b/json/targeting.yaml
@@ -291,6 +291,7 @@ type: object
   stringCompareArgs:
     type: array
     minItems: 2
+    maxItems: 2
     items:
       $ref: "#/$defs/stringCompareArg"
   stringCompareRule:
@@ -303,7 +304,7 @@ type: object
         $ref: "#/$defs/stringCompareArgs"
       ends_with:
         title: Ends-With Operation
-        description: Attribute ends with the specified value.
+        description: The string attribute ends with the specified string value.
         $ref: "#/$defs/stringCompareArgs"
   semVerString:
     title: Semantic Version String

--- a/json/targeting.yaml
+++ b/json/targeting.yaml
@@ -299,7 +299,7 @@ type: object
     properties:
       starts_with:
         title: Starts-With Operation
-        description: Attribute starts with the specified value.
+        description: The string attribute starts with the specified string value.
         $ref: "#/$defs/stringCompareArgs"
       ends_with:
         title: Ends-With Operation

--- a/json/targeting.yaml
+++ b/json/targeting.yaml
@@ -1,4 +1,4 @@
-$id: "https://flagd.dev/schema/targeting.json"
+$id: "https://flagd.dev/schema/v0/targeting.json"
 $schema: http://json-schema.org/draft-07/schema#
 title: flagd Targeting
 description: Defines targeting logic for flagd; a extension of JSONLogic, including
@@ -104,7 +104,7 @@ type: object
           form accepting more than 3 arguments (if/else) is not supported in flagd;
           use nesting instead.'
         type: array
-        minItems: 3
+        minItems: 2
         maxItems: 3
         items:
           $ref: "#/$defs/args"

--- a/json/targeting.yaml
+++ b/json/targeting.yaml
@@ -1,3 +1,4 @@
+$id: "flagd.dev/schema/targeting.json"
 $schema: http://json-schema.org/draft-07/schema#
 title: flagd Targeting
 description: Defines targeting logic for flagd; a extension of JSONLogic, including
@@ -10,7 +11,7 @@ type: object
       used as a targeting key, or null (to fall back to defaultVariant). If targeting
       returns a value which is not a variant key, it's considered an error.
     anyOf:
-    - "$comment": we need this to support empty targeting
+    - $comment: we need this to support empty targeting
       type: object
       additionalProperties: false
       properties: {}
@@ -46,9 +47,20 @@ type: object
         - type: string
           pattern: "^(?!\\$flagd\\.).+"
         - type: array
+          $comment: this is to support the form of var with a default... there seems to be a bug here, where ajv gives a warning (not an error) because maxItems doesn't equal the number of entries in items, though this is valid in this case
+          minItems: 1
           items:
-          - type: string
-          - type: {}
+            - type: string
+          additionalItems: 
+            anyOf:
+              - type:
+                  'null'
+              - type:
+                  boolean
+              - type: 
+                  string
+              - type:
+                  number
   missingRule:
     title: Missing Operation
     description: Takes an array of data keys to search for (same format as var). Returns
@@ -69,6 +81,8 @@ type: object
     additionalProperties: false
     properties:
       missing_some:
+        minItems: 2
+        maxItems: 2
         type: array
         items:
         - type: number
@@ -78,16 +92,16 @@ type: object
   ifRule:
     type: object
     additionalProperties: false
-    minItems: 3
-    maxItems: 3
     properties:
       if:
         title: If Operator
         description: 'The if statement takes 3 arguments: a condition (if), what to
-          do if it’s true (then), and what to do if it’s false (else). Note that the
+          do if its true (then), and what to do if its false (else). Note that the
           form accepting more than 3 arguments (if/else) is not supported in flagd;
           use nesting instead.'
         type: array
+        minItems: 3
+        maxItems: 3
         items:
           $ref: "#/$defs/args"
   binaryOp:
@@ -229,6 +243,7 @@ type: object
     items:
       $ref: "#/$defs/args"
   variadicRule:
+    $comment: "note < and <= can be used with up to 3 ops (between)"
     type: object
     additionalProperties: false
     properties:
@@ -242,7 +257,6 @@ type: object
         description: Simple boolean test, with 1 or more arguments. At a more sophisticated
           level, "and" returns the first falsy argument, or the last argument.
         $ref: "#/$defs/variadicOp"
-      "$comment": "< and <= can be used with up to 3 ops (between)"
       "<":
         title: Less-Than/Between Operation. Can be used to test that one value is
           between two others.
@@ -304,6 +318,7 @@ type: object
           "^" (match major version).'
         type: array
         minItems: 3
+        maxItems: 3
         items:
         - oneOf:
           - $ref: "#/$defs/semVerString"
@@ -323,7 +338,7 @@ type: object
           - $ref: "#/$defs/semVerString"
           - $ref: "#/$defs/varRule"
   fractionalWeightArg:
-    "$comment": if we remove the "some to 100" restriction, update the descriptions
+    $comment: if we remove the "some to 100" restriction, update the descriptions
       below!
     description: Distribution for all possible variants, with their associated weighting
       out of 100.
@@ -334,17 +349,19 @@ type: object
     - description: If this bucket is randomly selected, this string is used to as
         a key to retrieve the associated value from the "variants" object.
       type: string
-    additionalItems:
-      description: Weighted distribution for this variant key (must sum to 100).
+    - description: Weighted distribution for this variant key (must sum to 100).
       type: number
   fractionalOp:
     type: array
     minItems: 3
+    $comment: there seems to be a bug here, where ajv gives a warning (not an error) because maxItems doesn't equal the number of entries in items, though this is valid in this case
     items:
     - description: Bucketing value used in pseudorandom assignment; should be unique
         and stable for each subject of flag evaluation. Defaults to a concatenation
         of the flagKey and targetingKey.
       $ref: "#/$defs/varRule"
+    - $ref: "#/$defs/fractionalWeightArg"
+    - $ref: "#/$defs/fractionalWeightArg"
     additionalItems:
       $ref: "#/$defs/fractionalWeightArg"
   fractionalShorthandOp:

--- a/json/targeting.yaml
+++ b/json/targeting.yaml
@@ -1,0 +1,390 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: flagd Targeting
+description: Defines targeting logic for flagd; a extension of JSONLogic, including
+  purpose-built feature-flagging operations.
+type: object
+"$defs":
+  targeting:
+    title: Targeting
+    description: An expression returning a value which is coerced to a string to be
+      used as a targeting key, or null (to fall back to defaultVariant). If targeting
+      returns a value which is not a variant key, it's considered an error.
+    anyOf:
+    - "$comment": we need this to support empty targeting
+      type: object
+      additionalProperties: false
+      properties: {}
+    - $ref: "#/$defs/anyRule"
+  primitive:
+    oneOf:
+    - description: When returned from rules, a null value "exits", the targeting,
+        and the "defaultValue" is returned, with the reason indicating the targeting
+        did not match.
+      type: 'null'
+    - description: When returned from rules, booleans are converted to strings ("true"/"false"),
+        and used to as keys to retrieve the associated value from the "variants" object.
+        Be sure that the returned string is present as a key in the variants!
+      type: boolean
+    - description: When returned from rules, the behavior of numbers is not defined.
+      type: number
+    - description: When returned from rules, strings are used to as keys to retrieve
+        the associated value from the "variants" object. Be sure that the returned
+        string is present as a key in the variants!.
+      type: string
+  varRule:
+    title: Var Operation
+    description: Retrieve data from the provided data object.
+    type: object
+    additionalProperties: false
+    properties:
+      var:
+        anyOf:
+        - type: string
+          description: flagd automatically injects "$lagd.timestamp" (unix epoch)
+            and "$lagd.flagKey" (the key of the flag in evaluation) into the context.
+          pattern: "^\\$flagd\\.((timestamp)|(flagKey))$"
+        - type: string
+          pattern: "^(?!\\$flagd\\.).+"
+        - type: array
+          items:
+          - type: string
+          - type: {}
+  missingRule:
+    title: Missing Operation
+    description: Takes an array of data keys to search for (same format as var). Returns
+      an array of any keys that are missing from the data object, or an empty array.
+    type: object
+    additionalProperties: false
+    properties:
+      missing:
+        type: array
+        items:
+          type: string
+  missingSomeRule:
+    title: Missing-Some Operation
+    description: Takes a minimum number of data keys that are required, and an array
+      of keys to search for (same format as var or missing). Returns an empty array
+      if the minimum is met, or an array of the missing keys otherwise.
+    type: object
+    additionalProperties: false
+    properties:
+      missing_some:
+        type: array
+        items:
+        - type: number
+        - type: array
+          items:
+            type: string
+  ifRule:
+    type: object
+    additionalProperties: false
+    minItems: 3
+    maxItems: 3
+    properties:
+      if:
+        title: If Operator
+        description: 'The if statement takes 3 arguments: a condition (if), what to
+          do if it’s true (then), and what to do if it’s false (else). Note that the
+          form accepting more than 3 arguments (if/else) is not supported in flagd;
+          use nesting instead.'
+        type: array
+        items:
+          $ref: "#/$defs/args"
+  binaryOp:
+    type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      $ref: "#/$defs/args"
+  binaryRule:
+    title: Binary Operation
+    description: Any primitive JSONLogic operation with 2 operands.
+    type: object
+    additionalProperties: false
+    properties:
+      "==":
+        title: Lose Equality Operation
+        description: Tests equality, with type coercion. Requires two arguments.
+        $ref: "#/$defs/binaryOp"
+      "===":
+        title: Strict Equality Operation
+        description: Tests strict equality. Requires two arguments.
+        $ref: "#/$defs/binaryOp"
+      "!=":
+        title: Lose Inequality Operation
+        description: Tests not-equal, with type coercion.
+        $ref: "#/$defs/binaryOp"
+      "!==":
+        title: Strict Inequality Operation
+        description: Tests strict not-equal.
+        $ref: "#/$defs/binaryOp"
+      ">":
+        title: Greater-Than Operation
+        $ref: "#/$defs/binaryOp"
+      ">=":
+        title: Greater-Than-Or-Equal-To Operation
+        $ref: "#/$defs/binaryOp"
+      "%":
+        title: Modulo Operation
+        description: Finds the remainder after the first argument is divided by the
+          second argument.
+        $ref: "#/$defs/binaryOp"
+      map:
+        title: Map Operation
+        description: Perform an action on every member of an array. Note, that inside
+          the logic being used to map, var operations are relative to the array element
+          being worked on.
+        $ref: "#/$defs/binaryOp"
+      reduce:
+        title: Reduce Operation
+        description: Combine all the elements in an array into a single value, like
+          adding up a list of numbers. Note, that inside the logic being used to reduce,
+          var operations only have access to an object with a "current" and a "accumulator".
+        $ref: "#/$defs/binaryOp"
+      filter:
+        title: Filter Operation
+        description: Keep only elements of the array that pass a test. Note, that
+          inside the logic being used to filter, var operations are relative to the
+          array element being worked on.
+        $ref: "#/$defs/binaryOp"
+      all:
+        title: All Operation
+        description: Perform a test on each member of that array, returning true if
+          all pass. Inside the test code, var operations are relative to the array
+          element being tested.
+        $ref: "#/$defs/binaryOp"
+      none:
+        title: None Operation
+        description: Perform a test on each member of that array, returning true if
+          none pass. Inside the test code, var operations are relative to the array
+          element being tested.
+        $ref: "#/$defs/binaryOp"
+      some:
+        title: Some Operation
+        description: Perform a test on each member of that array, returning true if
+          some pass. Inside the test code, var operations are relative to the array
+          element being tested.
+        $ref: "#/$defs/binaryOp"
+      in:
+        title: In Operation
+        description: If the second argument is an array, tests that the first argument
+          is a member of the array.
+        $ref: "#/$defs/binaryOp"
+      substr:
+        title: Substring Operation
+        description: Get a portion of a string, given a positive start position as
+          an index (indexes of course start at zero).
+        $ref: "#/$defs/binaryOp"
+  associativeOp:
+    type: array
+    minItems: 2
+    items:
+      $ref: "#/$defs/args"
+  associativeRule:
+    title: Mathematically Associative Operation
+    description: Pperation applicable to 2 or more parameters.
+    type: object
+    additionalProperties: false
+    properties:
+      "+":
+        title: Addition Operation
+        description: Addition; associative, will accept and unlimited amount of arguments.
+        $ref: "#/$defs/associativeOp"
+      "*":
+        title: Multiplication Operation
+        description: Multiplication; associative, will accept and unlimited amount
+          of arguments.
+        $ref: "#/$defs/associativeOp"
+  unaryOp:
+    type: array
+    minItems: 1
+    maxItems: 1
+    items:
+      $ref: "#/$defs/args"
+  unaryRule:
+    title: Unary Operation
+    description: Any primitive JSONLogic operation with 1 operands.
+    type: object
+    additionalProperties: false
+    properties:
+      "!":
+        title: Negation Operation
+        description: Logical negation (“not”). Takes just one argument.
+        $ref: "#/$defs/unaryOp"
+      "!!":
+        title: Double Negation Operation
+        description: Double negation, or 'cast to a boolean'. Takes a single argument.
+        $ref: "#/$defs/unaryOp"
+      max:
+        title: Maximum Operation
+        description: Return the maximum from a list of values.
+        $ref: "#/$defs/unaryOp"
+      min:
+        title: Minimum Operation
+        description: Return the minimum from a list of values.
+        $ref: "#/$defs/unaryOp"
+  variadicOp:
+    type: array
+    minItems: 1
+    items:
+      $ref: "#/$defs/args"
+  variadicRule:
+    type: object
+    additionalProperties: false
+    properties:
+      or:
+        title: Or Operation
+        description: Simple boolean test, with 1 or more arguments. At a more sophisticated
+          level, "or" returns the first truthy argument, or the last argument.
+        $ref: "#/$defs/variadicOp"
+      and:
+        title: ''
+        description: Simple boolean test, with 1 or more arguments. At a more sophisticated
+          level, "and" returns the first falsy argument, or the last argument.
+        $ref: "#/$defs/variadicOp"
+      "$comment": "< and <= can be used with up to 3 ops (between)"
+      "<":
+        title: Less-Than/Between Operation. Can be used to test that one value is
+          between two others.
+        description: ''
+        $ref: "#/$defs/variadicOp"
+      "<=":
+        title: Less-Than-Or-Equal-To/Between Operation. Can be used to test that one
+          value is between two others.
+        description: ''
+        $ref: "#/$defs/variadicOp"
+      "-":
+        title: Subtraction Operation
+        $ref: "#/$defs/variadicOp"
+      merge:
+        title: Subtraction Operation
+        description: Takes one or more arrays, and merges them into one array. If
+          arguments aren't arrays, they get cast to arrays.
+        $ref: "#/$defs/variadicOp"
+      cat:
+        title: Concatenate Operation
+        description: Concatenate all the supplied arguments. Note that this is not
+          a join or implode operation, there is no “glue” string.
+        $ref: "#/$defs/variadicOp"
+  stringCompareArg:
+    oneOf:
+    - type: string
+    - $ref: "#/$defs/anyRule"
+  stringCompareArgs:
+    type: array
+    minItems: 2
+    items:
+      $ref: "#/$defs/stringCompareArg"
+  stringCompareRule:
+    type: object
+    additionalProperties: false
+    properties:
+      starts_with:
+        title: Starts-With Operation
+        description: Attribute starts with the specified value.
+        $ref: "#/$defs/stringCompareArgs"
+      ends_with:
+        title: Ends-With Operation
+        description: Attribute ends with the specified value.
+        $ref: "#/$defs/stringCompareArgs"
+  semVerString:
+    title: Semantic Version String
+    description: A string representing a valid semantic version expression as per
+      https://semver.org/.
+    type: string
+    pattern: "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+  ruleSemVer:
+    type: object
+    additionalProperties: false
+    properties:
+      sem_ver:
+        title: Semantic Version Operation
+        description: 'Attribute matches a semantic version condition. Accepts "npm-style"
+          range specifiers: "=", "!=", ">", "<", ">=", "<=", "~" (match minor version),
+          "^" (match major version).'
+        type: array
+        minItems: 3
+        items:
+        - oneOf:
+          - $ref: "#/$defs/semVerString"
+          - $ref: "#/$defs/varRule"
+        - description: 'Range specifiers: "=", "!=", ">", "<", ">=", "<=", "~" (match
+            minor version), "^" (match major version).'
+          enum:
+          - "="
+          - "!="
+          - ">"
+          - "<"
+          - ">="
+          - "<="
+          - "~"
+          - "^"
+        - oneOf:
+          - $ref: "#/$defs/semVerString"
+          - $ref: "#/$defs/varRule"
+  fractionalWeightArg:
+    "$comment": if we remove the "some to 100" restriction, update the descriptions
+      below!
+    description: Distribution for all possible variants, with their associated weighting
+      out of 100.
+    type: array
+    minItems: 2
+    maxItems: 2
+    items:
+    - description: If this bucket is randomly selected, this string is used to as
+        a key to retrieve the associated value from the "variants" object.
+      type: string
+    additionalItems:
+      description: Weighted distribution for this variant key (must sum to 100).
+      type: number
+  fractionalOp:
+    type: array
+    minItems: 3
+    items:
+    - description: Bucketing value used in pseudorandom assignment; should be unique
+        and stable for each subject of flag evaluation. Defaults to a concatenation
+        of the flagKey and targetingKey.
+      $ref: "#/$defs/varRule"
+    additionalItems:
+      $ref: "#/$defs/fractionalWeightArg"
+  fractionalShorthandOp:
+    type: array
+    minItems: 2
+    items:
+      $ref: "#/$defs/fractionalWeightArg"
+  fractionalRule:
+    type: object
+    additionalProperties: false
+    properties:
+      fractional:
+        title: Fractional Operation
+        description: Deterministic, pseudorandom fractional distribution.
+        oneOf:
+        - $ref: "#/$defs/fractionalOp"
+        - $ref: "#/$defs/fractionalShorthandOp"
+  reference:
+    additionalProperties: false
+    type: object
+    properties:
+      $ref:
+        title: Reference
+        description: A reference to another entity, used for $evaluators (shared rules).
+        type: string
+  args:
+    oneOf:
+    - $ref: "#/$defs/reference"
+    - $ref: "#/$defs/anyRule"
+    - $ref: "#/$defs/primitive"
+  anyRule:
+    oneOf:
+    - $ref: "#/$defs/varRule"
+    - $ref: "#/$defs/missingRule"
+    - $ref: "#/$defs/missingSomeRule"
+    - $ref: "#/$defs/ifRule"
+    - $ref: "#/$defs/binaryRule"
+    - $ref: "#/$defs/associativeRule"
+    - $ref: "#/$defs/unaryRule"
+    - $ref: "#/$defs/variadicRule"
+    - $ref: "#/$defs/stringCompareRule"
+    - $ref: "#/$defs/ruleSemVer"
+    - $ref: "#/$defs/fractionalRule"

--- a/json/test/negative/fractional-invalid-bucketing.json
+++ b/json/test/negative/fractional-invalid-bucketing.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../flagd-definitions.json",
+  "$comments": "tests that an invalid bucking value is invalid",
+  "flags": {
+    "fractional-invalid-bucketing": {
+      "state": "ENABLED",
+      "variants": {
+        "clubs": "clubs",
+        "diamonds": "diamonds",
+        "hearts": "hearts",
+        "spades": "spades",
+        "none": "none"
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "fractional": [
+          "invalid",
+          ["clubs", 25],
+          ["diamonds", 25],
+          ["hearts", 25],
+          ["spades", 25]
+        ]
+      }
+    }
+  }
+}

--- a/json/test/negative/fractional-invalid-weighting.json
+++ b/json/test/negative/fractional-invalid-weighting.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../flagd-definitions.json",
+  "$comments": "tests that an invalid weight value is invalid",
+  "flags": {
+    "fractional-invalid-weighting": {
+      "state": "ENABLED",
+      "variants": {
+        "clubs": "clubs",
+        "diamonds": "diamonds",
+        "hearts": "hearts",
+        "spades": "spades",
+        "none": "none"
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "fractional": [
+          ["clubs", 25],
+          ["diamonds", "25"],
+          ["hearts", 25],
+          ["spades", 25]
+        ]
+      }
+    }
+  }
+}

--- a/json/test/negative/invalid-ends-with-param.json
+++ b/json/test/negative/invalid-ends-with-param.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../../flagd-definitions.json",
+  "$comments": "tests that an an int is not a valid ends_with param",
+  "flags": {
+    "invalid-ends-with-param": {
+      "state": "ENABLED",
+      "variants": {
+        "prefix": 1,
+        "postfix": 2
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "if": [
+          {
+            "ends_with": [{ "var": "id" }, 0]
+          },
+          "postfix",
+          "prefix"
+        ]
+      }
+    }
+  }
+}

--- a/json/test/negative/invalid-flagd-props.json
+++ b/json/test/negative/invalid-flagd-props.json
@@ -12,7 +12,7 @@
       "targeting": {
         "if": [
           {
-            "==": [{ "var": "$flagd.myprop" }, { "var": "someprop" }]
+            "==": [{ "var": "$flagd.invalidProp" }, { "var": "someprop" }]
           },
           "yes",
           "no"

--- a/json/test/negative/invalid-flagd-props.json
+++ b/json/test/negative/invalid-flagd-props.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../../flagd-definitions.json",
+  "$comments": "tests that an unsupported $flagd property is invalid",
+  "flags": {
+    "invalid-flagd-props": {
+      "state": "ENABLED",
+      "variants": {
+        "yes": "1",
+        "no": "2"
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "if": [
+          {
+            "==": [{ "var": "$flagd.myprop" }, { "var": "someprop" }]
+          },
+          "yes",
+          "no"
+        ]
+      }
+    }
+  }
+}

--- a/json/test/negative/invalid-starts-with-param.json
+++ b/json/test/negative/invalid-starts-with-param.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../../flagd-definitions.json",
+  "$comments": "tests that an an int is not a valid starts_with param",
+  "flags": {
+    "invalid-starts-with-param": {
+      "state": "ENABLED",
+      "variants": {
+        "prefix": 1,
+        "postfix": 2
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "if": [
+          {
+            "starts_with": [{ "var": "id" }, 0]
+          },
+          "prefix",
+          "postfix"
+        ]
+      }
+    }
+  }
+}

--- a/json/test/negative/sem-ver-invalid-range-specifier.json
+++ b/json/test/negative/sem-ver-invalid-range-specifier.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../../flagd-definitions.json",
+  "$comments": "tests that an invalid range specifier is invalid",
+  "flags": {
+    "sem-ver-invalid-range-specifier": {
+      "state": "ENABLED",
+      "variants": {
+        "equal": "equal",
+        "not": "not"
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "if": [
+          {
+            "sem_ver": [{ "var": "version" }, "*", "2.0.0"]
+          },
+          "equal",
+          "not"
+        ]
+      }
+    }
+  }
+}

--- a/json/test/negative/sem-ver-invalid-ver-expression.json
+++ b/json/test/negative/sem-ver-invalid-ver-expression.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../../flagd-definitions.json",
+  "$comments": "tests that an invalid version is invalid",
+  "flags": {
+    "sem-ver-invalid-ver-expression": {
+      "state": "ENABLED",
+      "variants": {
+        "equal": "equal",
+        "not": "not"
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "if": [
+          {
+            "sem_ver": [{ "var": "version" }, "=", "2.0.0.0"]
+          },
+          "equal",
+          "not"
+        ]
+      }
+    }
+  }
+}

--- a/json/test/positive/custom-ops.json
+++ b/json/test/positive/custom-ops.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "../../flagd-definitions.json",
+  "$comments": "tests that all the custom ops work",
+  "flags": {
+    "fractional-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "clubs": "clubs",
+        "diamonds": "diamonds",
+        "hearts": "hearts",
+        "spades": "spades",
+        "wild": "wild"
+      },
+      "defaultVariant": "wild",
+      "targeting": {
+        "fractional": [
+          { "var": "user.name" },
+          ["clubs", 25],
+          ["diamonds", 25],
+          ["hearts", 25],
+          ["spades", 25]
+        ]
+      }
+    },
+    "shorthand-fractional-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "clubs": "clubs",
+        "diamonds": "diamonds",
+        "hearts": "hearts",
+        "spades": "spades",
+        "wild": "wild"
+      },
+      "defaultVariant": "wild",
+      "targeting": {
+        "fractional": [
+          ["clubs", 25],
+          ["diamonds", 25],
+          ["hearts", 25],
+          ["spades", 25]
+        ]
+      }
+    },
+    "starts-ends-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "prefix": "prefix",
+        "postfix": "postfix",
+        "none": "none"
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "if": [
+          {
+            "starts_with": [{ "var": "id" }, "abc"]
+          },
+          "prefix",
+          {
+            "if": [
+              {
+                "ends_with": [{ "var": "id" }, "xyz"]
+              },
+              "postfix",
+              null
+            ]
+          }
+        ]
+      }
+    },
+    "equal-greater-lesser-version-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "equal": "equal",
+        "greater": "greater",
+        "lesser": "lesser",
+        "none": "none"
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "if": [
+          {
+            "sem_ver": [{ "var": "version" }, "=", "2.0.0"]
+          },
+          "equal",
+          {
+            "if": [
+              {
+                "sem_ver": [{ "var": "version" }, ">", "2.0.0"]
+              },
+              "greater",
+              {
+                "if": [
+                  {
+                    "sem_ver": [{ "var": "version" }, "<", "2.0.0"]
+                  },
+                  "lesser",
+                  null
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "major-minor-version-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "minor": "minor",
+        "major": "major",
+        "none": "none"
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "if": [
+          {
+            "sem_ver": [{ "var": "version" }, "~", "3.0.0"]
+          },
+          "minor",
+          {
+            "if": [
+              {
+                "sem_ver": [{ "var": "version" }, "^", "3.0.0"]
+              },
+              "major",
+              "none"
+            ]
+          }
+        ]
+      }
+    },
+    "timestamp-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "past": -1,
+        "future": 1,
+        "none": 0
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "if": [
+          {
+            ">": [{ "var": "$flagd.timestamp" }, { "var": "time" }]
+          },
+          "past",
+          {
+            "if": [
+              {
+                "<": [{ "var": "$flagd.timestamp" }, { "var": "time" }]
+              },
+              "future",
+              "none"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/json/test/positive/example.flagd.json
+++ b/json/test/positive/example.flagd.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../flagd-definitions.json",
   "flags": {
     "myBoolFlag": {
       "state": "ENABLED",
@@ -56,9 +57,7 @@
           {
             "==": [
               {
-                "var": [
-                  "color"
-                ]
+                "var": ["color"]
               },
               "yellow"
             ]
@@ -81,7 +80,9 @@
         "if": [
           {
             "$ref": "emailWithFaas"
-          }, "binet", null
+          },
+          "binet",
+          null
         ]
       }
     },
@@ -97,38 +98,30 @@
       "targeting": {
         "if": [
           {
-            "$ref": "emailWithFaas"
+            "$ref": 1
           },
           {
             "fractionalEvaluation": [
               "email",
-              [
-                "red",
-                25
-              ],
-              [
-                "blue",
-                25
-              ],
-              [
-                "green",
-                25
-              ],
-              [
-                "yellow",
-                25
-              ]
+              ["red", 25],
+              ["blue", 25],
+              ["green", 25],
+              ["yellow", 25]
             ]
-          }, null
+          },
+          null
         ]
       }
     }
-    },
-    "$evaluators": {
-      "emailWithFaas": {
-            "in": ["@faas.com", {
-              "var": ["email"]
-            }]
-      }
+  },
+  "$evaluators": {
+    "emailWithFaas": {
+      "in": [
+        "@faas.com",
+        {
+          "var": ["email"]
+        }
+      ]
     }
   }
+}

--- a/json/test/positive/example.flagd.json
+++ b/json/test/positive/example.flagd.json
@@ -98,11 +98,11 @@
       "targeting": {
         "if": [
           {
-            "$ref": 1
+            "$ref": "emailWithFaas"
           },
           {
-            "fractionalEvaluation": [
-              "email",
+            "fractional": [
+              { "var": "email" },
               ["red", 25],
               ["blue", 25],
               ["green", 25],


### PR DESCRIPTION
This PR:

- adds JSON-schema validation for targeting rules
  - basic JSONLogic rules validated
  - custom rules (`sem_ver`, `fractional`, `starts/ends_with`) are fully validated 
  - descriptions are added for all operations and operands
  - `$evalutators` validated
  - maintained in separate schema
- improves flag-definition schema
  - descriptions added/improved

I've also added a bunch of positive and negative tests.

For a preview, add `"$schema": "https://deploy-preview-1115--polite-licorice-3db33c.netlify.app/schema/v0/flagd-definitions.json"` as a sibling to `"flags"` in your flagd config.

Closes: https://github.com/open-feature/flagd-schemas/issues/115

:warning: KEEP IN MIND WHEN REVIEWING that that `.yaml` files are the source of truth; the CI checks that the json is consistent with them.

![validation](https://github.com/open-feature/flagd-schemas/assets/25272906/d29fc404-0014-47ed-b5ad-60255fc124b5)
