### PR TITLE
feat!: improve naming, fix module url

### DIFF
--- a/.github/schema-store-issue-template.md
+++ b/.github/schema-store-issue-template.md
@@ -1,9 +1,8 @@
 ---
-title: "chore: add {{ env.TAG }} to schema store"
+title: "chore: update flagd.dev, and schema store"
 ---
 
-JSON schema released with tag {{ env.TAG }}. 
-This needs to be added to the schema store catalog.  
+# Update Schema Store JSON Schema
 
 [Schema store repo](https://github.com/SchemaStore/schemastore)
 
@@ -21,9 +20,14 @@ Extend the catalog entry found in `src/api/json/catalog.json` to include the new
     "*.flagd.yaml",
     "*.flagd.yml"
     ],
-    "url": "https://raw.githubusercontent.com/open-feature/schemas/main/json/flagd-definitions.json",
+    "url": "https://flagd.dev/schema/v0/flags.json",
     "versions": {
     "0.1.1": "https://raw.githubusercontent.com/open-feature/schemas/json/json-schema-v0.1.1/json/flagd-definitions.json",
 +   "X.X.X": "https://raw.githubusercontent.com/open-feature/schemas/json/json-schema-vX.X.X/json/flagd-definitions.json"
 }
 ```
+
+# Update flagd.dev JSON Schema
+
+[flagd.dev](https://flagd.dev/) hosts the canonical schema at: https://flagd.dev/schema/vX/flags.json (where X is the major version number).
+See the [Makefile in flagd](https://github.com/open-feature/flagd/blob/main/Makefile) for instructions on how to update this version.

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -44,20 +44,3 @@ jobs:
       # Push module to the BSR
       - name: bsr-push
         run: BUF_TOKEN="${{ secrets.BUF_TOKEN }}" buf push --tag "${{ needs.release-please.outputs.buf_release_tag }}" protobuf
-
-  create-schema-store-issue:
-    needs: release-please
-    name: create schema release reminder issue
-    runs-on: ubuntu-latest
-    if: ${{ needs.release-please.outputs.releases_created && needs.release-please.outputs.json_release_tag }}
-    steps:
-      # Run `git checkout`
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ needs.release-please.outputs.json_release_tag }}
-      - uses: JasonEtco/create-an-issue@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ needs.release-please.outputs.json_release_tag }}
-        with:
-          filename: .github/schema-store-issue-template.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,5 +11,5 @@ TLDR: be respectful.
 ### flagd JSON schema
 
 The flagd JSON schema defines the json structure used within flagd for flag configurations.   
-To contribute to the schema, make changes in `json/flagd-definitions.yaml`, these changes should then be propagated to `json/flagd-definitions.json` by running `make gen-schema-json`.  
+To contribute to the schema, make changes in `json/flags.yaml`, these changes should then be propagated to `json/flags.json` by running `make gen-schema-json`.  
 Unit testing for the schema is managed through [json/test/negative](./json/test/negative) (in which all json files must fail validation against the schema) and [json/test/positive](./json/test/positive) (in which all json files must pass).

--- a/Makefile
+++ b/Makefile
@@ -43,15 +43,15 @@ gen-rust: install-buf guard-GOPATH
 	${GOPATH}/bin/buf generate buf.build/open-feature/flagd --template protobuf/buf.gen.rust.yaml
 
 gen-schema-json: install-yq
-	yq eval -o=json json/flagd-definitions.yaml > json/flagd-definitions.json
+	yq eval -o=json json/flags.yaml > json/flags.json
 	yq eval -o=json json/targeting.yaml > json/targeting.json
 	
 .PHONY: test
-test:
+test: gen-schema-json ajv-validate-flagd-schema
 	go test -v ./json
 
 ajv-validate-flagd-schema:
 	@if ! npm ls ajv-cli; then npm ci; fi
 	npx ajv compile -s json/targeting.json
-# 	load the targeting json so flagd-definitions.json can reference it
-	npx ajv compile -r json/targeting.json -s json/flagd-definitions.json
+# 	load the targeting json so flag.json can reference it
+	npx ajv compile -r json/targeting.json -s json/flags.json

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/open-feature/schemas
+module github.com/open-feature/flagd-schemas
 
 go 1.18
 

--- a/json/examples/full.json
+++ b/json/examples/full.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../flagd-definitions.json",
+  "$schema": "../flags.json",
   "flags": {
     "myBoolFlag": {
       "state": "ENABLED",

--- a/json/flagd_definitions.go
+++ b/json/flagd_definitions.go
@@ -2,8 +2,8 @@ package flagd_definitions
 
 import _ "embed"
 
-//go:embed flagd-definitions.json
-var FlagdDefinitions string
+//go:embed flags.json
+var FlagSchema string
 
 //go:embed targeting.json
-var Targeting string
+var TargetingSchema string

--- a/json/flagd_definitions_test.go
+++ b/json/flagd_definitions_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	flagd_definitions "github.com/open-feature/schemas/json"
+	flagd_definitions "github.com/open-feature/flagd-schemas/json"
 
 	"github.com/xeipuuv/gojsonschema"
 )
@@ -17,9 +17,9 @@ var compiledSchema *gojsonschema.Schema
 
 func init() {
 	schemaLoader := gojsonschema.NewSchemaLoader()
-	schemaLoader.AddSchemas(gojsonschema.NewStringLoader(flagd_definitions.Targeting))
+	schemaLoader.AddSchemas(gojsonschema.NewStringLoader(flagd_definitions.TargetingSchema))
 	var err error
-	compiledSchema, err = schemaLoader.Compile(gojsonschema.NewStringLoader(flagd_definitions.FlagdDefinitions))
+	compiledSchema, err = schemaLoader.Compile(gojsonschema.NewStringLoader(flagd_definitions.FlagSchema))
 	if err != nil {
 		message := fmt.Errorf("err: %v", err)
 		log.Fatal(message)

--- a/json/flags.json
+++ b/json/flags.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://flagd.dev/schema/v0/flagd-definitions.json",
+  "$id": "https://flagd.dev/schema/v0/flags.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "flagd Flag Configuration",
   "description": "Defines flags for use in flagd, including typed variants and rules",

--- a/json/flags.yaml
+++ b/json/flags.yaml
@@ -1,4 +1,4 @@
-$id: "https://flagd.dev/schema/v0/flagd-definitions.json"
+$id: "https://flagd.dev/schema/v0/flags.json"
 $schema: http://json-schema.org/draft-07/schema#
 title: flagd Flag Configuration
 description: Defines flags for use in flagd, including typed variants and rules

--- a/json/test/negative/empty-variants.json
+++ b/json/test/negative/empty-variants.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../flagd-definitions.json",
+  "$schema": "../../flags.json",
   "flags": {
     "myBoolFlag": {
       "state": "ENABLED",

--- a/json/test/negative/fractional-invalid-bucketing.json
+++ b/json/test/negative/fractional-invalid-bucketing.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../flagd-definitions.json",
+  "$schema": "../../flags.json",
   "$comments": "tests that an invalid bucking value is invalid",
   "flags": {
     "fractional-invalid-bucketing": {

--- a/json/test/negative/fractional-invalid-weighting.json
+++ b/json/test/negative/fractional-invalid-weighting.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../flagd-definitions.json",
+  "$schema": "../../flags.json",
   "$comments": "tests that an invalid weight value is invalid",
   "flags": {
     "fractional-invalid-weighting": {

--- a/json/test/negative/invalid-ends-with-param.json
+++ b/json/test/negative/invalid-ends-with-param.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../flagd-definitions.json",
+  "$schema": "../../flags.json",
   "$comments": "tests that an an int is not a valid ends_with param",
   "flags": {
     "invalid-ends-with-param": {

--- a/json/test/negative/invalid-flagd-props.json
+++ b/json/test/negative/invalid-flagd-props.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../flagd-definitions.json",
+  "$schema": "../../flags.json",
   "$comments": "tests that an unsupported $flagd property is invalid",
   "flags": {
     "invalid-flagd-props": {

--- a/json/test/negative/invalid-starts-with-param.json
+++ b/json/test/negative/invalid-starts-with-param.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../flagd-definitions.json",
+  "$schema": "../../flags.json",
   "$comments": "tests that an an int is not a valid starts_with param",
   "flags": {
     "invalid-starts-with-param": {

--- a/json/test/negative/malformed-flag.json
+++ b/json/test/negative/malformed-flag.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../flagd-definitions.json",
+  "$schema": "../../flags.json",
   "flags": {
     "myBoolFlag": {
       "state": "ENABLED",

--- a/json/test/negative/missing-variants.json
+++ b/json/test/negative/missing-variants.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../flagd-definitions.json",
+  "$schema": "../../flags.json",
 
   "flags": {
     "myBoolFlag": {

--- a/json/test/negative/mixed-variant-types.ffconfig.json
+++ b/json/test/negative/mixed-variant-types.ffconfig.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../flagd-definitions.json",
+  "$schema": "../../flags.json",
   "flags": {
     "myBoolFlag": {
       "state": "ENABLED",

--- a/json/test/negative/no-default-variant.json
+++ b/json/test/negative/no-default-variant.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../flagd-definitions.json",
+  "$schema": "../../flags.json",
   "flags": {
     "myBoolFlag": {
       "state": "ENABLED",

--- a/json/test/negative/sem-ver-invalid-range-specifier.json
+++ b/json/test/negative/sem-ver-invalid-range-specifier.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../flagd-definitions.json",
+  "$schema": "../../flags.json",
   "$comments": "tests that an invalid range specifier is invalid",
   "flags": {
     "sem-ver-invalid-range-specifier": {

--- a/json/test/negative/sem-ver-invalid-ver-expression.json
+++ b/json/test/negative/sem-ver-invalid-ver-expression.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../flagd-definitions.json",
+  "$schema": "../../flags.json",
   "$comments": "tests that an invalid version is invalid",
   "flags": {
     "sem-ver-invalid-ver-expression": {

--- a/json/test/negative/state-set-incorrectly.json
+++ b/json/test/negative/state-set-incorrectly.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../flagd-definitions.json",
+  "$schema": "../../flags.json",
   "flags": {
     "myBoolFlag": {
       "state": "WILL-FAIL",

--- a/json/test/positive/basic-json-ops.json
+++ b/json/test/positive/basic-json-ops.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../flagd-definitions.json",
+  "$schema": "../../flags.json",
   "flags": {
     "basic-json-ops": {
       "state": "ENABLED",

--- a/json/test/positive/custom-ops.json
+++ b/json/test/positive/custom-ops.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../flagd-definitions.json",
+  "$schema": "../../flags.json",
   "$comments": "tests that all the custom ops work",
   "flags": {
     "fractional-flag": {

--- a/json/test/positive/example.flagd.json
+++ b/json/test/positive/example.flagd.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../flagd-definitions.json",
+  "$schema": "../../flags.json",
   "flags": {
     "myBoolFlag": {
       "state": "ENABLED",


### PR DESCRIPTION
- Fixes module location
- changes flagd root level schema name to `flags.json` instead of `flagd_definitions`
  - "flags" is the main top level object of the root schema, and though we have others (like `$evalutors` they are optional and used in `flags`.
  - it seems much more sensible as a public schema: https://flagd.dev/schema/v0/flagd-definitions.json vs https://flagd.dev/schema/v0/flags.json

Fixes: https://github.com/open-feature/flagd-schemas/issues/125