### PR TITLE
feat!: struct for metadata for consistency and power

### DIFF
--- a/protobuf/flagd/sync/v1/sync.proto
+++ b/protobuf/flagd/sync/v1/sync.proto
@@ -8,6 +8,8 @@ syntax = "proto3";
 
 package flagd.sync.v1;
 
+import "google/protobuf/struct.proto";
+
 option csharp_namespace = "OpenFeature.Flagd.Grpc.Sync";
 option go_package = "flagd/sync/v1";
 option java_package = "dev.openfeature.flagd.grpc.sync";

--- a/protobuf/flagd/sync/v1/sync.proto
+++ b/protobuf/flagd/sync/v1/sync.proto
@@ -64,13 +64,7 @@ message GetMetadataRequest {}
 
 // GetMetadataResponse contains metadata from the sync service
 message GetMetadataResponse {
-  repeated KeyValue metadata = 1;
-}
-
-// KeyValue represents a key/value pair
-message KeyValue {
-  string key = 1;
-  string value = 2;
+  google.protobuf.Struct metadata = 1;
 }
 
 // FlagService implements a server streaming to provide realtime flag configurations

--- a/protobuf/flagd/sync/v1/sync.proto
+++ b/protobuf/flagd/sync/v1/sync.proto
@@ -66,7 +66,8 @@ message GetMetadataRequest {}
 
 // GetMetadataResponse contains metadata from the sync service
 message GetMetadataResponse {
-  google.protobuf.Struct metadata = 1;
+  reserved 1; // old key/value metadata impl
+  google.protobuf.Struct metadata = 2;
 }
 
 // FlagService implements a server streaming to provide realtime flag configurations


### PR DESCRIPTION
This PR alters the _new_ schemas to use maps consistently for all metadata.

Previously, the `getMetadata` RPC was returning a custom key/val response, which is the old proto2 way of doing maps.

Additionally, for consistency, I have changed the flag metadata to `map<string, string>` as well. This is a "more" breaking change, but it's consistent and will allow for much stronger typing. If there's a need for more flexibility in flag metadata, we can revert.

We can avoid this change if the breaking is a concern, but I think it's save to assume nobody but us are using this new proto.