### PR TITLE
fix: workaround bad $ref derefs

### DIFF
--- a/json/targeting.json
+++ b/json/targeting.json
@@ -527,8 +527,9 @@
     "reference": {
       "additionalProperties": false,
       "type": "object",
-      "properties": {
-        "$ref": {
+      "$comment": "patternProperties here is a bit of a hack to prevent this definition from being dereferenced early.",
+      "patternProperties": {
+        "^\\$ref$": {
           "title": "Reference",
           "description": "A reference to another entity, used for $evaluators (shared rules).",
           "type": "string"

--- a/json/targeting.yaml
+++ b/json/targeting.yaml
@@ -412,8 +412,9 @@ type: object
   reference:
     additionalProperties: false
     type: object
-    properties:
-      $ref:
+    $comment: patternProperties here is a bit of a hack to prevent this definition from being dereferenced early.
+    patternProperties:
+      '^\$ref$':
         title: Reference
         description: A reference to another entity, used for $evaluators (shared rules).
         type: string


### PR DESCRIPTION
When some parsers see `$ref`, they immediately and unconditionally read its value as a string and attempt to dereference it... this is not what we want to happen here, we want to actually support our own `$ref` values in our configs, so we have to define `"$ref"` as an actual entity in our schema.

This is a bit of a hack that doesn't impact the functionality of our schema, and dodges the issue by removing the `"$ref"` key in question and using a regex instead.

see: https://cloud-native.slack.com/archives/C03J36ZP020/p1709149248098079?thread_ts=1709139281.745429&cid=C03J36ZP020