### PR TITLE
feat: allow custom seed in fractional op

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: 1.20.7
+  GO_VERSION: 1.22
 
 jobs:
   lint-protos:

--- a/json/targeting.json
+++ b/json/targeting.json
@@ -486,7 +486,7 @@
       "items": [
         {
           "description": "Bucketing value used in pseudorandom assignment; should be unique and stable for each subject of flag evaluation. Defaults to a concatenation of the flagKey and targetingKey.",
-          "$ref": "#/$defs/varRule"
+          "$ref": "#/$defs/anyRule"
         },
         {
           "$ref": "#/$defs/fractionalWeightArg"
@@ -506,37 +506,6 @@
         "$ref": "#/$defs/fractionalWeightArg"
       }
     },
-    "fractionalCustomSeedOp": {
-      "type": "array",
-      "minItems": 4,
-      "$comment": "there seems to be a bug here, where ajv gives a warning (not an error) because maxItems doesn't equal the number of entries in items, though this is valid in this case",
-      "items": [
-        {
-          "description": "Bucketing value used in pseudorandom assignment; should be unique and stable for each subject of flag evaluation. Defaults to targetingKey.",
-          "$ref": "#/$defs/varRule"
-        },
-        {
-          "description": "Seed used in pseudorandom assignment. Defaults to flagKey.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/varRule"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        {
-          "$ref": "#/$defs/fractionalWeightArg"
-        },
-        {
-          "$ref": "#/$defs/fractionalWeightArg"
-        }
-      ],
-      "additionalItems": {
-        "$ref": "#/$defs/fractionalWeightArg"
-      }
-    },
     "fractionalRule": {
       "type": "object",
       "additionalProperties": false,
@@ -545,9 +514,6 @@
           "title": "Fractional Operation",
           "description": "Deterministic, pseudorandom fractional distribution.",
           "oneOf": [
-            {
-              "$ref": "#/$defs/fractionalCustomSeedOp"
-            },
             {
               "$ref": "#/$defs/fractionalOp"
             },

--- a/json/targeting.json
+++ b/json/targeting.json
@@ -506,6 +506,37 @@
         "$ref": "#/$defs/fractionalWeightArg"
       }
     },
+    "fractionalCustomSeedOp": {
+      "type": "array",
+      "minItems": 4,
+      "$comment": "there seems to be a bug here, where ajv gives a warning (not an error) because maxItems doesn't equal the number of entries in items, though this is valid in this case",
+      "items": [
+        {
+          "description": "Bucketing value used in pseudorandom assignment; should be unique and stable for each subject of flag evaluation. Defaults to targetingKey.",
+          "$ref": "#/$defs/varRule"
+        },
+        {
+          "description": "Seed used in pseudorandom assignment. Defaults to flagKey.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/varRule"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "$ref": "#/$defs/fractionalWeightArg"
+        },
+        {
+          "$ref": "#/$defs/fractionalWeightArg"
+        }
+      ],
+      "additionalItems": {
+        "$ref": "#/$defs/fractionalWeightArg"
+      }
+    },
     "fractionalRule": {
       "type": "object",
       "additionalProperties": false,
@@ -514,6 +545,9 @@
           "title": "Fractional Operation",
           "description": "Deterministic, pseudorandom fractional distribution.",
           "oneOf": [
+            {
+              "$ref": "#/$defs/fractionalCustomSeedOp"
+            },
             {
               "$ref": "#/$defs/fractionalOp"
             },

--- a/json/targeting.yaml
+++ b/json/targeting.yaml
@@ -389,7 +389,7 @@ type: object
     - description: Bucketing value used in pseudorandom assignment; should be unique
         and stable for each subject of flag evaluation. Defaults to a concatenation
         of the flagKey and targetingKey.
-      $ref: "#/$defs/varRule"
+      $ref: "#/$defs/anyRule"
     - $ref: "#/$defs/fractionalWeightArg"
     - $ref: "#/$defs/fractionalWeightArg"
     additionalItems:
@@ -399,22 +399,6 @@ type: object
     minItems: 2
     items:
       $ref: "#/$defs/fractionalWeightArg"
-  fractionalCustomSeedOp:
-    type: array
-    minItems: 4
-    $comment: there seems to be a bug here, where ajv gives a warning (not an error) because maxItems doesn't equal the number of entries in items, though this is valid in this case
-    items:
-    - description: Bucketing value used in pseudorandom assignment; should be unique
-        and stable for each subject of flag evaluation. Defaults to targetingKey.
-      $ref: "#/$defs/varRule"
-    - description: Seed used in pseudorandom assignment. Defaults to flagKey.
-      anyOf:
-      - $ref: "#/$defs/varRule"
-      - type: string
-    - $ref: "#/$defs/fractionalWeightArg"
-    - $ref: "#/$defs/fractionalWeightArg"
-    additionalItems:
-      $ref: "#/$defs/fractionalWeightArg"
   fractionalRule:
     type: object
     additionalProperties: false
@@ -423,7 +407,6 @@ type: object
         title: Fractional Operation
         description: Deterministic, pseudorandom fractional distribution.
         oneOf:
-        - $ref: "#/$defs/fractionalCustomSeedOp"
         - $ref: "#/$defs/fractionalOp"
         - $ref: "#/$defs/fractionalShorthandOp"
   reference:

--- a/json/targeting.yaml
+++ b/json/targeting.yaml
@@ -399,6 +399,22 @@ type: object
     minItems: 2
     items:
       $ref: "#/$defs/fractionalWeightArg"
+  fractionalCustomSeedOp:
+    type: array
+    minItems: 4
+    $comment: there seems to be a bug here, where ajv gives a warning (not an error) because maxItems doesn't equal the number of entries in items, though this is valid in this case
+    items:
+    - description: Bucketing value used in pseudorandom assignment; should be unique
+        and stable for each subject of flag evaluation. Defaults to targetingKey.
+      $ref: "#/$defs/varRule"
+    - description: Seed used in pseudorandom assignment. Defaults to flagKey.
+      anyOf:
+      - $ref: "#/$defs/varRule"
+      - type: string
+    - $ref: "#/$defs/fractionalWeightArg"
+    - $ref: "#/$defs/fractionalWeightArg"
+    additionalItems:
+      $ref: "#/$defs/fractionalWeightArg"
   fractionalRule:
     type: object
     additionalProperties: false
@@ -407,6 +423,7 @@ type: object
         title: Fractional Operation
         description: Deterministic, pseudorandom fractional distribution.
         oneOf:
+        - $ref: "#/$defs/fractionalCustomSeedOp"
         - $ref: "#/$defs/fractionalOp"
         - $ref: "#/$defs/fractionalShorthandOp"
   reference:

--- a/json/test/positive/custom-ops.json
+++ b/json/test/positive/custom-ops.json
@@ -41,6 +41,27 @@
         ]
       }
     },
+    "custom-seed-fractional-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "clubs": "clubs",
+        "diamonds": "diamonds",
+        "hearts": "hearts",
+        "spades": "spades",
+        "wild": "wild"
+      },
+      "defaultVariant": "wild",
+      "targeting": {
+        "fractional": [
+          { "var": "user.name" },
+          "my-seed",
+          ["clubs", 25],
+          ["diamonds", 25],
+          ["hearts", 25],
+          ["spades", 25]
+        ]
+      }
+    },
     "starts-ends-flag": {
       "state": "ENABLED",
       "variants": {

--- a/json/test/positive/custom-ops.json
+++ b/json/test/positive/custom-ops.json
@@ -14,7 +14,10 @@
       "defaultVariant": "wild",
       "targeting": {
         "fractional": [
-          { "var": "user.name" },
+          { "cat": [
+            { "var": "$flagd.flagKey" },
+            { "var": "user.name" }
+          ]},
           ["clubs", 25],
           ["diamonds", 25],
           ["hearts", 25],
@@ -34,27 +37,6 @@
       "defaultVariant": "wild",
       "targeting": {
         "fractional": [
-          ["clubs", 25],
-          ["diamonds", 25],
-          ["hearts", 25],
-          ["spades", 25]
-        ]
-      }
-    },
-    "custom-seed-fractional-flag": {
-      "state": "ENABLED",
-      "variants": {
-        "clubs": "clubs",
-        "diamonds": "diamonds",
-        "hearts": "hearts",
-        "spades": "spades",
-        "wild": "wild"
-      },
-      "defaultVariant": "wild",
-      "targeting": {
-        "fractional": [
-          { "var": "user.name" },
-          "my-seed",
           ["clubs", 25],
           ["diamonds", 25],
           ["hearts", 25],


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- updates fractional schema to accept complex rules as first argument to override targeting so that we can support using `cat` and other rules to provide custom seeds to randomisation

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

https://github.com/open-feature/flagd/issues/1264
resolves https://github.com/open-feature/flagd/issues/1265

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

see https://github.com/open-feature/flagd/pull/1266
