### PR TITLE
fix: change $defs to definitions per draft07

### DIFF
--- a/json/flags.json
+++ b/json/flags.json
@@ -9,7 +9,7 @@
       "title": "Flags",
       "description": "Top-level flags object. All flags are defined here.",
       "type": "object",
-      "$comment": "flag objects are one of the 4 flag types defined in $defs",
+      "$comment": "flag objects are one of the 4 flag types defined in definitions",
       "additionalProperties": false,
       "patternProperties": {
         "^.{1,}$": {
@@ -17,22 +17,22 @@
             {
               "title": "Boolean flag",
               "description": "A flag having boolean values.",
-              "$ref": "#/$defs/booleanFlag"
+              "$ref": "#/definitions/booleanFlag"
             },
             {
               "title": "String flag",
               "description": "A flag having string values.",
-              "$ref": "#/$defs/stringFlag"
+              "$ref": "#/definitions/stringFlag"
             },
             {
               "title": "Numeric flag",
               "description": "A flag having numeric values.",
-              "$ref": "#/$defs/numberFlag"
+              "$ref": "#/definitions/numberFlag"
             },
             {
               "title": "Object flag",
               "description": "A flag having arbitrary object values.",
-              "$ref": "#/$defs/objectFlag"
+              "$ref": "#/definitions/objectFlag"
             }
           ]
         }
@@ -46,12 +46,12 @@
       "patternProperties": {
         "^.{1,}$": {
           "$comment": "this relative ref means that targeting.json MUST be in the same dir, or available on the same HTTP path",
-          "$ref": "./targeting.json#/$defs/targeting"
+          "$ref": "./targeting.json#/definitions/targeting"
         }
       }
     }
   },
-  "$defs": {
+  "definitions": {
     "flag": {
       "$comment": "base flag object; no title/description here, allows for better UX, keep it in the overrides",
       "type": "object",
@@ -71,7 +71,7 @@
           "type": "string"
         },
         "targeting": {
-          "$ref": "./targeting.json#/$defs/targeting"
+          "$ref": "./targeting.json#/definitions/targeting"
         }
       },
       "required": [
@@ -139,44 +139,44 @@
         }
       }
     },
-    "$comment": "merge the variants with the base flag to build our typed flags",
     "booleanFlag": {
+      "$comment": "merge the variants with the base flag to build our typed flags",
       "allOf": [
         {
-          "$ref": "#/$defs/flag"
+          "$ref": "#/definitions/flag"
         },
         {
-          "$ref": "#/$defs/booleanVariants"
+          "$ref": "#/definitions/booleanVariants"
         }
       ]
     },
     "stringFlag": {
       "allOf": [
         {
-          "$ref": "#/$defs/flag"
+          "$ref": "#/definitions/flag"
         },
         {
-          "$ref": "#/$defs/stringVariants"
+          "$ref": "#/definitions/stringVariants"
         }
       ]
     },
     "numberFlag": {
       "allOf": [
         {
-          "$ref": "#/$defs/flag"
+          "$ref": "#/definitions/flag"
         },
         {
-          "$ref": "#/$defs/numberVariants"
+          "$ref": "#/definitions/numberVariants"
         }
       ]
     },
     "objectFlag": {
       "allOf": [
         {
-          "$ref": "#/$defs/flag"
+          "$ref": "#/definitions/flag"
         },
         {
-          "$ref": "#/$defs/objectVariants"
+          "$ref": "#/definitions/objectVariants"
         }
       ]
     }

--- a/json/flags.yaml
+++ b/json/flags.yaml
@@ -8,23 +8,23 @@ properties:
     title: Flags
     description: Top-level flags object. All flags are defined here.
     type: object
-    $comment: flag objects are one of the 4 flag types defined in $defs
+    $comment: flag objects are one of the 4 flag types defined in definitions
     additionalProperties: false
     patternProperties:
       "^.{1,}$":
         oneOf:
         - title: Boolean flag
           description: A flag having boolean values.
-          $ref: "#/$defs/booleanFlag"
+          $ref: "#/definitions/booleanFlag"
         - title: String flag
           description: A flag having string values.
-          $ref: "#/$defs/stringFlag"
+          $ref: "#/definitions/stringFlag"
         - title: Numeric flag
           description: A flag having numeric values.
-          $ref: "#/$defs/numberFlag"
+          $ref: "#/definitions/numberFlag"
         - title: Object flag
           description: A flag having arbitrary object values.
-          $ref: "#/$defs/objectFlag"
+          $ref: "#/definitions/objectFlag"
   $evaluators:
     title: Evaluators
     description: 'Reusable targeting rules that can be referenced with "$ref": "myRule"
@@ -35,8 +35,8 @@ properties:
       "^.{1,}$":
         $comment: this relative ref means that targeting.json MUST be in the same
           dir, or available on the same HTTP path
-        $ref: "./targeting.json#/$defs/targeting"
-"$defs":
+        $ref: "./targeting.json#/definitions/targeting"
+definitions:
   flag:
     $comment: base flag object; no title/description here, allows for better UX,
       keep it in the overrides
@@ -56,7 +56,7 @@ properties:
           if the targeting returns null).
         type: string
       targeting:
-        $ref: "./targeting.json#/$defs/targeting"
+        $ref: "./targeting.json#/definitions/targeting"
     required:
     - state
     - defaultVariant
@@ -99,20 +99,20 @@ properties:
         patternProperties:
           "^.{1,}$":
             type: object
-  $comment: merge the variants with the base flag to build our typed flags
   booleanFlag:
+    $comment: merge the variants with the base flag to build our typed flags
     allOf:
-    - $ref: "#/$defs/flag"
-    - $ref: "#/$defs/booleanVariants"
+    - $ref: "#/definitions/flag"
+    - $ref: "#/definitions/booleanVariants"
   stringFlag:
     allOf:
-    - $ref: "#/$defs/flag"
-    - $ref: "#/$defs/stringVariants"
+    - $ref: "#/definitions/flag"
+    - $ref: "#/definitions/stringVariants"
   numberFlag:
     allOf:
-    - $ref: "#/$defs/flag"
-    - $ref: "#/$defs/numberVariants"
+    - $ref: "#/definitions/flag"
+    - $ref: "#/definitions/numberVariants"
   objectFlag:
     allOf:
-    - $ref: "#/$defs/flag"
-    - $ref: "#/$defs/objectVariants"
+    - $ref: "#/definitions/flag"
+    - $ref: "#/definitions/objectVariants"

--- a/json/targeting.json
+++ b/json/targeting.json
@@ -4,7 +4,7 @@
   "title": "flagd Targeting",
   "description": "Defines targeting logic for flagd; a extension of JSONLogic, including purpose-built feature-flagging operations.",
   "type": "object",
-  "$defs": {
+  "definitions": {
     "targeting": {
       "title": "Targeting",
       "description": "An expression returning a value which is coerced to a string to be used as a targeting key, or null (to fall back to defaultVariant). If targeting returns a value which is not a variant key, it's considered an error.",
@@ -16,7 +16,7 @@
           "properties": {}
         },
         {
-          "$ref": "#/$defs/anyRule"
+          "$ref": "#/definitions/anyRule"
         }
       ]
     },
@@ -138,7 +138,7 @@
       "minItems": 2,
       "maxItems": 3,
       "items": {
-        "$ref": "#/$defs/args"
+        "$ref": "#/definitions/args"
       }
     },
     "binaryOrTernaryRule": {
@@ -148,15 +148,15 @@
         "substr": {
           "title": "Substring Operation",
           "description": "Get a portion of a string. Give a positive start position to return everything beginning at that index. Give a negative start position to work backwards from the end of the string, then return everything. Give a positive length to express how many characters to return.",
-          "$ref": "#/$defs/binaryOrTernaryOp"
+          "$ref": "#/definitions/binaryOrTernaryOp"
         },
         "<": {
           "title": "Less-Than/Between Operation. Can be used to test that one value is between two others.",
-          "$ref": "#/$defs/binaryOrTernaryOp"
+          "$ref": "#/definitions/binaryOrTernaryOp"
         },
         "<=": {
           "title": "Less-Than-Or-Equal-To/Between Operation. Can be used to test that one value is between two others.",
-          "$ref": "#/$defs/binaryOrTernaryOp"
+          "$ref": "#/definitions/binaryOrTernaryOp"
         }
       }
     },
@@ -165,7 +165,7 @@
       "minItems": 2,
       "maxItems": 2,
       "items": {
-        "$ref": "#/$defs/args"
+        "$ref": "#/definitions/args"
       }
     },
     "binaryRule": {
@@ -177,74 +177,74 @@
         "if": {
           "title": "If Operator",
           "description": "The if statement takes 1 or more arguments: a condition (\"if\"), what to do if its true (\"then\", optional, defaults to returning true), and what to do if its false (\"else\", optional, defaults to returning false). Note that the else condition can be used as an else-if statement by adding additional arguments.",
-          "$ref": "#/$defs/variadicOp"
+          "$ref": "#/definitions/variadicOp"
         },
         "==": {
           "title": "Lose Equality Operation",
           "description": "Tests equality, with type coercion. Requires two arguments.",
-          "$ref": "#/$defs/binaryOp"
+          "$ref": "#/definitions/binaryOp"
         },
         "===": {
           "title": "Strict Equality Operation",
           "description": "Tests strict equality. Requires two arguments.",
-          "$ref": "#/$defs/binaryOp"
+          "$ref": "#/definitions/binaryOp"
         },
         "!=": {
           "title": "Lose Inequality Operation",
           "description": "Tests not-equal, with type coercion.",
-          "$ref": "#/$defs/binaryOp"
+          "$ref": "#/definitions/binaryOp"
         },
         "!==": {
           "title": "Strict Inequality Operation",
           "description": "Tests strict not-equal.",
-          "$ref": "#/$defs/binaryOp"
+          "$ref": "#/definitions/binaryOp"
         },
         ">": {
           "title": "Greater-Than Operation",
-          "$ref": "#/$defs/binaryOp"
+          "$ref": "#/definitions/binaryOp"
         },
         ">=": {
           "title": "Greater-Than-Or-Equal-To Operation",
-          "$ref": "#/$defs/binaryOp"
+          "$ref": "#/definitions/binaryOp"
         },
         "%": {
           "title": "Modulo Operation",
           "description": "Finds the remainder after the first argument is divided by the second argument.",
-          "$ref": "#/$defs/binaryOp"
+          "$ref": "#/definitions/binaryOp"
         },
         "/": {
           "title": "Division Operation",
-          "$ref": "#/$defs/binaryOp"
+          "$ref": "#/definitions/binaryOp"
         },
         "map": {
           "title": "Map Operation",
           "description": "Perform an action on every member of an array. Note, that inside the logic being used to map, var operations are relative to the array element being worked on.",
-          "$ref": "#/$defs/binaryOp"
+          "$ref": "#/definitions/binaryOp"
         },
         "filter": {
           "title": "Filter Operation",
           "description": "Keep only elements of the array that pass a test. Note, that inside the logic being used to filter, var operations are relative to the array element being worked on.",
-          "$ref": "#/$defs/binaryOp"
+          "$ref": "#/definitions/binaryOp"
         },
         "all": {
           "title": "All Operation",
           "description": "Perform a test on each member of that array, returning true if all pass. Inside the test code, var operations are relative to the array element being tested.",
-          "$ref": "#/$defs/binaryOp"
+          "$ref": "#/definitions/binaryOp"
         },
         "none": {
           "title": "None Operation",
           "description": "Perform a test on each member of that array, returning true if none pass. Inside the test code, var operations are relative to the array element being tested.",
-          "$ref": "#/$defs/binaryOp"
+          "$ref": "#/definitions/binaryOp"
         },
         "some": {
           "title": "Some Operation",
           "description": "Perform a test on each member of that array, returning true if some pass. Inside the test code, var operations are relative to the array element being tested.",
-          "$ref": "#/$defs/binaryOp"
+          "$ref": "#/definitions/binaryOp"
         },
         "in": {
           "title": "In Operation",
           "description": "If the second argument is an array, tests that the first argument is a member of the array.",
-          "$ref": "#/$defs/binaryOp"
+          "$ref": "#/definitions/binaryOp"
         }
       }
     },
@@ -259,7 +259,7 @@
           "minItems": 3,
           "maxItems": 3,
           "items": {
-            "$ref": "#/$defs/args"
+            "$ref": "#/definitions/args"
           }
         }
       }
@@ -268,7 +268,7 @@
       "type": "array",
       "minItems": 2,
       "items": {
-        "$ref": "#/$defs/args"
+        "$ref": "#/definitions/args"
       }
     },
     "associativeRule": {
@@ -280,7 +280,7 @@
         "*": {
           "title": "Multiplication Operation",
           "description": "Multiplication; associative, will accept and unlimited amount of arguments.",
-          "$ref": "#/$defs/associativeOp"
+          "$ref": "#/definitions/associativeOp"
         }
       }
     },
@@ -289,7 +289,7 @@
       "minItems": 1,
       "maxItems": 1,
       "items": {
-        "$ref": "#/$defs/args"
+        "$ref": "#/definitions/args"
       }
     },
     "unaryRule": {
@@ -301,12 +301,12 @@
         "!": {
           "title": "Negation Operation",
           "description": "Logical negation (“not”). Takes just one argument.",
-          "$ref": "#/$defs/unaryOp"
+          "$ref": "#/definitions/unaryOp"
         },
         "!!": {
           "title": "Double Negation Operation",
           "description": "Double negation, or 'cast to a boolean'. Takes a single argument.",
-          "$ref": "#/$defs/unaryOp"
+          "$ref": "#/definitions/unaryOp"
         }
       }
     },
@@ -314,7 +314,7 @@
       "type": "array",
       "minItems": 1,
       "items": {
-        "$ref": "#/$defs/args"
+        "$ref": "#/definitions/args"
       }
     },
     "variadicRule": {
@@ -325,41 +325,41 @@
         "or": {
           "title": "Or Operation",
           "description": "Simple boolean test, with 1 or more arguments. At a more sophisticated level, \"or\" returns the first truthy argument, or the last argument.",
-          "$ref": "#/$defs/variadicOp"
+          "$ref": "#/definitions/variadicOp"
         },
         "and": {
           "title": "",
           "description": "Simple boolean test, with 1 or more arguments. At a more sophisticated level, \"and\" returns the first falsy argument, or the last argument.",
-          "$ref": "#/$defs/variadicOp"
+          "$ref": "#/definitions/variadicOp"
         },
         "+": {
           "title": "Addition Operation",
           "description": "Addition; associative, will accept and unlimited amount of arguments.",
-          "$ref": "#/$defs/variadicOp"
+          "$ref": "#/definitions/variadicOp"
         },
         "-": {
           "title": "Subtraction Operation",
-          "$ref": "#/$defs/variadicOp"
+          "$ref": "#/definitions/variadicOp"
         },
         "max": {
           "title": "Maximum Operation",
           "description": "Return the maximum from a list of values.",
-          "$ref": "#/$defs/variadicOp"
+          "$ref": "#/definitions/variadicOp"
         },
         "min": {
           "title": "Minimum Operation",
           "description": "Return the minimum from a list of values.",
-          "$ref": "#/$defs/variadicOp"
+          "$ref": "#/definitions/variadicOp"
         },
         "merge": {
           "title": "Merge Operation",
           "description": "Takes one or more arrays, and merges them into one array. If arguments aren't arrays, they get cast to arrays.",
-          "$ref": "#/$defs/variadicOp"
+          "$ref": "#/definitions/variadicOp"
         },
         "cat": {
           "title": "Concatenate Operation",
           "description": "Concatenate all the supplied arguments. Note that this is not a join or implode operation, there is no “glue” string.",
-          "$ref": "#/$defs/variadicOp"
+          "$ref": "#/definitions/variadicOp"
         }
       }
     },
@@ -369,7 +369,7 @@
           "type": "string"
         },
         {
-          "$ref": "#/$defs/anyRule"
+          "$ref": "#/definitions/anyRule"
         }
       ]
     },
@@ -378,7 +378,7 @@
       "minItems": 2,
       "maxItems": 2,
       "items": {
-        "$ref": "#/$defs/stringCompareArg"
+        "$ref": "#/definitions/stringCompareArg"
       }
     },
     "stringCompareRule": {
@@ -388,12 +388,12 @@
         "starts_with": {
           "title": "Starts-With Operation",
           "description": "The string attribute starts with the specified string value.",
-          "$ref": "#/$defs/stringCompareArgs"
+          "$ref": "#/definitions/stringCompareArgs"
         },
         "ends_with": {
           "title": "Ends-With Operation",
           "description": "The string attribute ends with the specified string value.",
-          "$ref": "#/$defs/stringCompareArgs"
+          "$ref": "#/definitions/stringCompareArgs"
         }
       }
     },
@@ -417,10 +417,10 @@
             {
               "oneOf": [
                 {
-                  "$ref": "#/$defs/semVerString"
+                  "$ref": "#/definitions/semVerString"
                 },
                 {
-                  "$ref": "#/$defs/varRule"
+                  "$ref": "#/definitions/varRule"
                 }
               ]
             },
@@ -440,10 +440,10 @@
             {
               "oneOf": [
                 {
-                  "$ref": "#/$defs/semVerString"
+                  "$ref": "#/definitions/semVerString"
                 },
                 {
-                  "$ref": "#/$defs/varRule"
+                  "$ref": "#/definitions/varRule"
                 }
               ]
             }
@@ -475,24 +475,24 @@
       "items": [
         {
           "description": "Bucketing value used in pseudorandom assignment; should be unique and stable for each subject of flag evaluation. Defaults to a concatenation of the flagKey and targetingKey.",
-          "$ref": "#/$defs/anyRule"
+          "$ref": "#/definitions/anyRule"
         },
         {
-          "$ref": "#/$defs/fractionalWeightArg"
+          "$ref": "#/definitions/fractionalWeightArg"
         },
         {
-          "$ref": "#/$defs/fractionalWeightArg"
+          "$ref": "#/definitions/fractionalWeightArg"
         }
       ],
       "additionalItems": {
-        "$ref": "#/$defs/fractionalWeightArg"
+        "$ref": "#/definitions/fractionalWeightArg"
       }
     },
     "fractionalShorthandOp": {
       "type": "array",
       "minItems": 2,
       "items": {
-        "$ref": "#/$defs/fractionalWeightArg"
+        "$ref": "#/definitions/fractionalWeightArg"
       }
     },
     "fractionalRule": {
@@ -504,10 +504,10 @@
           "description": "Deterministic, pseudorandom fractional distribution.",
           "oneOf": [
             {
-              "$ref": "#/$defs/fractionalOp"
+              "$ref": "#/definitions/fractionalOp"
             },
             {
-              "$ref": "#/$defs/fractionalShorthandOp"
+              "$ref": "#/definitions/fractionalShorthandOp"
             }
           ]
         }
@@ -528,53 +528,53 @@
     "args": {
       "oneOf": [
         {
-          "$ref": "#/$defs/reference"
+          "$ref": "#/definitions/reference"
         },
         {
-          "$ref": "#/$defs/anyRule"
+          "$ref": "#/definitions/anyRule"
         },
         {
-          "$ref": "#/$defs/primitive"
+          "$ref": "#/definitions/primitive"
         }
       ]
     },
     "anyRule": {
       "anyOf": [
         {
-          "$ref": "#/$defs/varRule"
+          "$ref": "#/definitions/varRule"
         },
         {
-          "$ref": "#/$defs/missingRule"
+          "$ref": "#/definitions/missingRule"
         },
         {
-          "$ref": "#/$defs/missingSomeRule"
+          "$ref": "#/definitions/missingSomeRule"
         },
         {
-          "$ref": "#/$defs/binaryRule"
+          "$ref": "#/definitions/binaryRule"
         },
         {
-          "$ref": "#/$defs/binaryOrTernaryRule"
+          "$ref": "#/definitions/binaryOrTernaryRule"
         },
         {
-          "$ref": "#/$defs/associativeRule"
+          "$ref": "#/definitions/associativeRule"
         },
         {
-          "$ref": "#/$defs/unaryRule"
+          "$ref": "#/definitions/unaryRule"
         },
         {
-          "$ref": "#/$defs/variadicRule"
+          "$ref": "#/definitions/variadicRule"
         },
         {
-          "$ref": "#/$defs/reduceRule"
+          "$ref": "#/definitions/reduceRule"
         },
         {
-          "$ref": "#/$defs/stringCompareRule"
+          "$ref": "#/definitions/stringCompareRule"
         },
         {
-          "$ref": "#/$defs/ruleSemVer"
+          "$ref": "#/definitions/ruleSemVer"
         },
         {
-          "$ref": "#/$defs/fractionalRule"
+          "$ref": "#/definitions/fractionalRule"
         }
       ]
     }

--- a/json/targeting.yaml
+++ b/json/targeting.yaml
@@ -4,7 +4,7 @@ title: flagd Targeting
 description: Defines targeting logic for flagd; a extension of JSONLogic, including
   purpose-built feature-flagging operations.
 type: object
-"$defs":
+definitions:
   targeting:
     title: Targeting
     description: An expression returning a value which is coerced to a string to be
@@ -15,7 +15,7 @@ type: object
       type: object
       additionalProperties: false
       properties: {}
-    - $ref: "#/$defs/anyRule"
+    - $ref: "#/definitions/anyRule"
   primitive:
     oneOf:
     - description: When returned from rules, a null value "exits", the targeting,
@@ -102,7 +102,7 @@ type: object
     minItems: 2
     maxItems: 3
     items:
-      $ref: "#/$defs/args"
+      $ref: "#/definitions/args"
   binaryOrTernaryRule:
     type: object
     additionalProperties: false
@@ -112,21 +112,21 @@ type: object
         description: Get a portion of a string. Give a positive start position to return everything beginning at that index.
           Give a negative start position to work backwards from the end of the string, then return everything.
           Give a positive length to express how many characters to return.
-        $ref: "#/$defs/binaryOrTernaryOp"
+        $ref: "#/definitions/binaryOrTernaryOp"
       "<":
         title: Less-Than/Between Operation. Can be used to test that one value is
           between two others.
-        $ref: "#/$defs/binaryOrTernaryOp"
+        $ref: "#/definitions/binaryOrTernaryOp"
       "<=":
         title: Less-Than-Or-Equal-To/Between Operation. Can be used to test that one
           value is between two others.
-        $ref: "#/$defs/binaryOrTernaryOp"
+        $ref: "#/definitions/binaryOrTernaryOp"
   binaryOp:
     type: array
     minItems: 2
     maxItems: 2
     items:
-      $ref: "#/$defs/args"
+      $ref: "#/definitions/args"
   binaryRule:
     title: Binary Operation
     description: Any primitive JSONLogic operation with 2 operands.
@@ -136,72 +136,72 @@ type: object
       "if":
         title: "If Operator"
         description: "The if statement takes 1 or more arguments: a condition (\"if\"), what to do if its true (\"then\", optional, defaults to returning true), and what to do if its false (\"else\", optional, defaults to returning false). Note that the else condition can be used as an else-if statement by adding additional arguments."
-        $ref: "#/$defs/variadicOp"
+        $ref: "#/definitions/variadicOp"
       "==":
         title: Lose Equality Operation
         description: Tests equality, with type coercion. Requires two arguments.
-        $ref: "#/$defs/binaryOp"
+        $ref: "#/definitions/binaryOp"
       "===":
         title: Strict Equality Operation
         description: Tests strict equality. Requires two arguments.
-        $ref: "#/$defs/binaryOp"
+        $ref: "#/definitions/binaryOp"
       "!=":
         title: Lose Inequality Operation
         description: Tests not-equal, with type coercion.
-        $ref: "#/$defs/binaryOp"
+        $ref: "#/definitions/binaryOp"
       "!==":
         title: Strict Inequality Operation
         description: Tests strict not-equal.
-        $ref: "#/$defs/binaryOp"
+        $ref: "#/definitions/binaryOp"
       ">":
         title: Greater-Than Operation
-        $ref: "#/$defs/binaryOp"
+        $ref: "#/definitions/binaryOp"
       ">=":
         title: Greater-Than-Or-Equal-To Operation
-        $ref: "#/$defs/binaryOp"
+        $ref: "#/definitions/binaryOp"
       "%":
         title: Modulo Operation
         description: Finds the remainder after the first argument is divided by the
           second argument.
-        $ref: "#/$defs/binaryOp"
+        $ref: "#/definitions/binaryOp"
       "/":
         title: Division Operation
-        $ref: "#/$defs/binaryOp"
+        $ref: "#/definitions/binaryOp"
       map:
         title: Map Operation
         description: Perform an action on every member of an array. Note, that inside
           the logic being used to map, var operations are relative to the array element
           being worked on.
-        $ref: "#/$defs/binaryOp"
+        $ref: "#/definitions/binaryOp"
       filter:
         title: Filter Operation
         description: Keep only elements of the array that pass a test. Note, that
           inside the logic being used to filter, var operations are relative to the
           array element being worked on.
-        $ref: "#/$defs/binaryOp"
+        $ref: "#/definitions/binaryOp"
       all:
         title: All Operation
         description: Perform a test on each member of that array, returning true if
           all pass. Inside the test code, var operations are relative to the array
           element being tested.
-        $ref: "#/$defs/binaryOp"
+        $ref: "#/definitions/binaryOp"
       none:
         title: None Operation
         description: Perform a test on each member of that array, returning true if
           none pass. Inside the test code, var operations are relative to the array
           element being tested.
-        $ref: "#/$defs/binaryOp"
+        $ref: "#/definitions/binaryOp"
       some:
         title: Some Operation
         description: Perform a test on each member of that array, returning true if
           some pass. Inside the test code, var operations are relative to the array
           element being tested.
-        $ref: "#/$defs/binaryOp"
+        $ref: "#/definitions/binaryOp"
       in:
         title: In Operation
         description: If the second argument is an array, tests that the first argument
           is a member of the array.
-        $ref: "#/$defs/binaryOp"
+        $ref: "#/definitions/binaryOp"
   reduceRule:
     type: object
     additionalProperties: false
@@ -215,12 +215,12 @@ type: object
         minItems: 3
         maxItems: 3
         items:
-          $ref: "#/$defs/args"
+          $ref: "#/definitions/args"
   associativeOp:
     type: array
     minItems: 2
     items:
-      $ref: "#/$defs/args"
+      $ref: "#/definitions/args"
   associativeRule:
     title: Mathematically Associative Operation
     description: Operation applicable to 2 or more parameters.
@@ -231,13 +231,13 @@ type: object
         title: Multiplication Operation
         description: Multiplication; associative, will accept and unlimited amount
           of arguments.
-        $ref: "#/$defs/associativeOp"
+        $ref: "#/definitions/associativeOp"
   unaryOp:
     type: array
     minItems: 1
     maxItems: 1
     items:
-      $ref: "#/$defs/args"
+      $ref: "#/definitions/args"
   unaryRule:
     title: Unary Operation
     description: Any primitive JSONLogic operation with 1 operands.
@@ -247,16 +247,16 @@ type: object
       "!":
         title: Negation Operation
         description: Logical negation (“not”). Takes just one argument.
-        $ref: "#/$defs/unaryOp"
+        $ref: "#/definitions/unaryOp"
       "!!":
         title: Double Negation Operation
         description: Double negation, or 'cast to a boolean'. Takes a single argument.
-        $ref: "#/$defs/unaryOp"
+        $ref: "#/definitions/unaryOp"
   variadicOp:
     type: array
     minItems: 1
     items:
-      $ref: "#/$defs/args"
+      $ref: "#/definitions/args"
   variadicRule:
     $comment: "note < and <= can be used with up to 3 ops (between)"
     type: object
@@ -266,47 +266,47 @@ type: object
         title: Or Operation
         description: Simple boolean test, with 1 or more arguments. At a more sophisticated
           level, "or" returns the first truthy argument, or the last argument.
-        $ref: "#/$defs/variadicOp"
+        $ref: "#/definitions/variadicOp"
       and:
         title: ''
         description: Simple boolean test, with 1 or more arguments. At a more sophisticated
           level, "and" returns the first falsy argument, or the last argument.
-        $ref: "#/$defs/variadicOp"
+        $ref: "#/definitions/variadicOp"
       "+":
         title: Addition Operation
         description: Addition; associative, will accept and unlimited amount of arguments.
-        $ref: "#/$defs/variadicOp"
+        $ref: "#/definitions/variadicOp"
       "-":
         title: Subtraction Operation
-        $ref: "#/$defs/variadicOp"
+        $ref: "#/definitions/variadicOp"
       max:
         title: Maximum Operation
         description: Return the maximum from a list of values.
-        $ref: "#/$defs/variadicOp"
+        $ref: "#/definitions/variadicOp"
       min:
         title: Minimum Operation
         description: Return the minimum from a list of values.
-        $ref: "#/$defs/variadicOp"
+        $ref: "#/definitions/variadicOp"
       merge:
         title: Merge Operation
         description: Takes one or more arrays, and merges them into one array. If
           arguments aren't arrays, they get cast to arrays.
-        $ref: "#/$defs/variadicOp"
+        $ref: "#/definitions/variadicOp"
       cat:
         title: Concatenate Operation
         description: Concatenate all the supplied arguments. Note that this is not
           a join or implode operation, there is no “glue” string.
-        $ref: "#/$defs/variadicOp"
+        $ref: "#/definitions/variadicOp"
   stringCompareArg:
     oneOf:
     - type: string
-    - $ref: "#/$defs/anyRule"
+    - $ref: "#/definitions/anyRule"
   stringCompareArgs:
     type: array
     minItems: 2
     maxItems: 2
     items:
-      $ref: "#/$defs/stringCompareArg"
+      $ref: "#/definitions/stringCompareArg"
   stringCompareRule:
     type: object
     additionalProperties: false
@@ -314,11 +314,11 @@ type: object
       starts_with:
         title: Starts-With Operation
         description: The string attribute starts with the specified string value.
-        $ref: "#/$defs/stringCompareArgs"
+        $ref: "#/definitions/stringCompareArgs"
       ends_with:
         title: Ends-With Operation
         description: The string attribute ends with the specified string value.
-        $ref: "#/$defs/stringCompareArgs"
+        $ref: "#/definitions/stringCompareArgs"
   semVerString:
     title: Semantic Version String
     description: A string representing a valid semantic version expression as per
@@ -339,8 +339,8 @@ type: object
         maxItems: 3
         items:
         - oneOf:
-          - $ref: "#/$defs/semVerString"
-          - $ref: "#/$defs/varRule"
+          - $ref: "#/definitions/semVerString"
+          - $ref: "#/definitions/varRule"
         - description: 'Range specifiers: "=", "!=", ">", "<", ">=", "<=", "~" (match
             minor version), "^" (match major version).'
           enum:
@@ -353,8 +353,8 @@ type: object
           - "~"
           - "^"
         - oneOf:
-          - $ref: "#/$defs/semVerString"
-          - $ref: "#/$defs/varRule"
+          - $ref: "#/definitions/semVerString"
+          - $ref: "#/definitions/varRule"
   fractionalWeightArg:
     $comment: if we remove the "sum to 100" restriction, update the descriptions
       below!
@@ -377,16 +377,16 @@ type: object
     - description: Bucketing value used in pseudorandom assignment; should be unique
         and stable for each subject of flag evaluation. Defaults to a concatenation
         of the flagKey and targetingKey.
-      $ref: "#/$defs/anyRule"
-    - $ref: "#/$defs/fractionalWeightArg"
-    - $ref: "#/$defs/fractionalWeightArg"
+      $ref: "#/definitions/anyRule"
+    - $ref: "#/definitions/fractionalWeightArg"
+    - $ref: "#/definitions/fractionalWeightArg"
     additionalItems:
-      $ref: "#/$defs/fractionalWeightArg"
+      $ref: "#/definitions/fractionalWeightArg"
   fractionalShorthandOp:
     type: array
     minItems: 2
     items:
-      $ref: "#/$defs/fractionalWeightArg"
+      $ref: "#/definitions/fractionalWeightArg"
   fractionalRule:
     type: object
     additionalProperties: false
@@ -395,8 +395,8 @@ type: object
         title: Fractional Operation
         description: Deterministic, pseudorandom fractional distribution.
         oneOf:
-        - $ref: "#/$defs/fractionalOp"
-        - $ref: "#/$defs/fractionalShorthandOp"
+        - $ref: "#/definitions/fractionalOp"
+        - $ref: "#/definitions/fractionalShorthandOp"
   reference:
     additionalProperties: false
     type: object
@@ -408,20 +408,20 @@ type: object
         type: string
   args:
     oneOf:
-    - $ref: "#/$defs/reference"
-    - $ref: "#/$defs/anyRule"
-    - $ref: "#/$defs/primitive"
+    - $ref: "#/definitions/reference"
+    - $ref: "#/definitions/anyRule"
+    - $ref: "#/definitions/primitive"
   anyRule:
     anyOf:
-    - $ref: "#/$defs/varRule"
-    - $ref: "#/$defs/missingRule"
-    - $ref: "#/$defs/missingSomeRule"
-    - $ref: "#/$defs/binaryRule"
-    - $ref: "#/$defs/binaryOrTernaryRule"
-    - $ref: "#/$defs/associativeRule"
-    - $ref: "#/$defs/unaryRule"
-    - $ref: "#/$defs/variadicRule"
-    - $ref: "#/$defs/reduceRule"
-    - $ref: "#/$defs/stringCompareRule"
-    - $ref: "#/$defs/ruleSemVer"
-    - $ref: "#/$defs/fractionalRule"
+    - $ref: "#/definitions/varRule"
+    - $ref: "#/definitions/missingRule"
+    - $ref: "#/definitions/missingSomeRule"
+    - $ref: "#/definitions/binaryRule"
+    - $ref: "#/definitions/binaryOrTernaryRule"
+    - $ref: "#/definitions/associativeRule"
+    - $ref: "#/definitions/unaryRule"
+    - $ref: "#/definitions/variadicRule"
+    - $ref: "#/definitions/reduceRule"
+    - $ref: "#/definitions/stringCompareRule"
+    - $ref: "#/definitions/ruleSemVer"
+    - $ref: "#/definitions/fractionalRule"


### PR DESCRIPTION
`$defs` works, but it its not part of draft07 which leads to odd warnings in some implementations.

I've switched this to `definitions` as per the spec.

see: https://json-schema.org/draft-07/draft-handrews-json-schema-validation-01#rfc.section.9

fixes: https://github.com/open-feature/flagd/issues/1309