### PR TITLE
fix: revert full schema versioning

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   GO_VERSION: 1.22
@@ -52,12 +52,10 @@ jobs:
           against: 'https://github.com/open-feature/schemas.git#branch=main,ref=HEAD~1,subdir=protobuf'
 
   
-  validate-and-sync-schema:
+  validate-schema:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       
       # Use ajv to validate schema
       - name: Setup node
@@ -74,18 +72,9 @@ jobs:
       - name: Validate Schema
         run: make test
 
-      # Sync JSON schemas from YAML versions
-      - name: Sync JSON from YAML
+      # Ensure there is no diff when make gen-schema-json is run 
+      - run: make gen-schema-json
+      - name: Check no diff 
         run: |
-          make gen-schema-json
-          if [ ! -z "$(git status --porcelain)" ]; then
-            echo "JSON schema generation produced diff, regenerating and committing result...";
-            git config --global user.name "validate-and-sync-schema-job"
-            git config --global user.email "bot@openfeature.dev"
-            git add json/*.json
-            git commit -m 'chore: sync json schema from yaml' -s
-            git push
-          else
-            echo "No delta between YAML and JSON schemas, finishing..."
-          fi
-
+          if [ ! -z "$(git status --porcelain)" ]; then echo "JSON schema generation produced diff. Run 'make gen-schema-json' and commit results."; exit 1; fi
+          

--- a/json/flags.json
+++ b/json/flags.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://flagd.dev/schema/v0.2.6/flags.json",
+  "$id": "https://flagd.dev/schema/v0/flags.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "flagd Flag Configuration",
   "description": "Defines flags for use in flagd, including typed variants and rules",

--- a/json/flags.yaml
+++ b/json/flags.yaml
@@ -1,4 +1,4 @@
-$id: "https://flagd.dev/schema/v0.2.6/flags.json" # x-release-please-version
+$id: "https://flagd.dev/schema/v0/flags.json"
 $schema: http://json-schema.org/draft-07/schema#
 title: flagd Flag Configuration
 description: Defines flags for use in flagd, including typed variants and rules

--- a/json/targeting.json
+++ b/json/targeting.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://flagd.dev/schema/v0.2.6/targeting.json",
+  "$id": "https://flagd.dev/schema/v0/targeting.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "flagd Targeting",
   "description": "Defines targeting logic for flagd; a extension of JSONLogic, including purpose-built feature-flagging operations.",

--- a/json/targeting.yaml
+++ b/json/targeting.yaml
@@ -1,4 +1,4 @@
-$id: "https://flagd.dev/schema/v0.2.6/targeting.json" # x-release-please-version
+$id: "https://flagd.dev/schema/v0/targeting.json"
 $schema: http://json-schema.org/draft-07/schema#
 title: flagd Targeting
 description: Defines targeting logic for flagd; a extension of JSONLogic, including

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,11 +14,7 @@
       "release-type": "simple",
       "prerelease": false,
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
-      "extra-files": [
-        "flags.yaml",
-        "targeting.yaml"
-      ]
+      "bump-patch-for-minor-pre-major": true
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
Reverts https://github.com/open-feature/flagd-schemas/pull/163. Though there's a lot of benefits, the maintenance burden here is too high.

It means we will need to update the schema version everywhere, frequently. For example, we'd have to update it in places like this: https://github.com/open-feature/java-sdk-contrib/blob/ae21165c2bd65cad325e66e8373fe38da8a98baf/providers/flagd/src/main/java/dev/openfeature/contrib/providers/flagd/resolver/process/model/FlagParser.java#L46-L47 .

I think this will be too error prone and too much of a maintenance burden for little benefit. I'm reverting back to only major version-based versioning.