### PR TITLE
feat: add flag set and flag metadata to schema

### DIFF
--- a/json/flags.json
+++ b/json/flags.json
@@ -209,7 +209,7 @@
           "boolean"
         ]
       },
-      "required": null
+      "required": []
     }
   }
 }

--- a/json/flags.json
+++ b/json/flags.json
@@ -54,12 +54,13 @@
       "title": "Flag Set Metadata",
       "description": "Metadata about the flag set, with keys of type string, and values of type boolean, string, or number.",
       "properties": {
-        "flagSetId": {
+        "id": {
           "description": "The unique identifier for the flag set.",
           "type": "string"
         },
         "version": {
-          "description": "The version of the flag set."
+          "description": "The version of the flag set.",
+          "type": "string"
         }
       },
       "$ref": "#/definitions/metadata"

--- a/json/flags.json
+++ b/json/flags.json
@@ -51,7 +51,7 @@
       }
     },
     "metadata": {
-      "name": "Flag Set Metadata",
+      "title": "Flag Set Metadata",
       "description": "Metadata about the flag set, with keys of type string, and values of type boolean, string, or number.",
       "properties": {
         "flagSetId": {

--- a/json/flags.json
+++ b/json/flags.json
@@ -54,13 +54,12 @@
       "title": "Flag Set Metadata",
       "description": "Metadata about the flag set, with keys of type string, and values of type boolean, string, or number.",
       "properties": {
-        "id": {
+        "flagSetId": {
           "description": "The unique identifier for the flag set.",
           "type": "string"
         },
         "version": {
-          "description": "The version of the flag set.",
-          "type": "string"
+          "description": "The version of the flag set."
         }
       },
       "$ref": "#/definitions/metadata"

--- a/json/flags.json
+++ b/json/flags.json
@@ -49,6 +49,20 @@
           "$ref": "./targeting.json"
         }
       }
+    },
+    "metadata": {
+      "name": "Flag Set Metadata",
+      "description": "Metadata about the flag set, with keys of type string, and values of type boolean, string, or number.",
+      "properties": {
+        "flagSetId": {
+          "description": "The unique identifier for the flag set.",
+          "type": "string"
+        },
+        "version": {
+          "description": "The version of the flag set."
+        }
+      },
+      "$ref": "#/definitions/metadata"
     }
   },
   "definitions": {
@@ -72,6 +86,11 @@
         },
         "targeting": {
           "$ref": "./targeting.json"
+        },
+        "metadata": {
+          "title": "Flag Metadata",
+          "description": "Metadata about an individual feature flag, with keys of type string, and values of type boolean, string, or number.",
+          "$ref": "#/definitions/metadata"
         }
       },
       "required": [
@@ -179,6 +198,18 @@
           "$ref": "#/definitions/objectVariants"
         }
       ]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "description": "Any additional key/value pair with value of type boolean, string, or number.",
+        "type": [
+          "string",
+          "number",
+          "boolean"
+        ]
+      },
+      "required": null
     }
   }
 }

--- a/json/flags.yaml
+++ b/json/flags.yaml
@@ -37,7 +37,7 @@ properties:
           dir, or available on the same HTTP path
         $ref: "./targeting.json"
   metadata:
-    name: Flag Set Metadata
+    title: Flag Set Metadata
     description: Metadata about the flag set, with keys of type string, and values of type boolean, string, or number.
     properties:
       flagSetId:

--- a/json/flags.yaml
+++ b/json/flags.yaml
@@ -139,4 +139,4 @@ definitions:
        - number
        - boolean
     # Metadata is optional
-    required:
+    required: []

--- a/json/flags.yaml
+++ b/json/flags.yaml
@@ -36,6 +36,16 @@ properties:
         $comment: this relative ref means that targeting.json MUST be in the same
           dir, or available on the same HTTP path
         $ref: "./targeting.json"
+  metadata:
+    name: Flag Set Metadata
+    description: Metadata about the flag set, with keys of type string, and values of type boolean, string, or number.
+    properties:
+      flagSetId:
+        description: The unique identifier for the flag set.
+        type: string
+      version:
+        description: The version of the flag set.
+    $ref: "#/definitions/metadata"
 definitions:
   flag:
     $comment: base flag object; no title/description here, allows for better UX,
@@ -57,6 +67,10 @@ definitions:
         type: string
       targeting:
         $ref: "./targeting.json"
+      metadata:
+        title: Flag Metadata
+        description: Metadata about an individual feature flag, with keys of type string, and values of type boolean, string, or number.
+        $ref: "#/definitions/metadata"
     required:
     - state
     - defaultVariant
@@ -116,3 +130,13 @@ definitions:
     allOf:
     - $ref: "#/definitions/flag"
     - $ref: "#/definitions/objectVariants"
+  metadata:
+    type: object
+    additionalProperties:
+      description: Any additional key/value pair with value of type boolean, string, or number.
+      type:
+       - string
+       - number
+       - boolean
+    # Metadata is optional
+    required:

--- a/json/flags.yaml
+++ b/json/flags.yaml
@@ -40,11 +40,12 @@ properties:
     title: Flag Set Metadata
     description: Metadata about the flag set, with keys of type string, and values of type boolean, string, or number.
     properties:
-      flagSetId:
+      id:
         description: The unique identifier for the flag set.
         type: string
       version:
         description: The version of the flag set.
+        type: string
     $ref: "#/definitions/metadata"
 definitions:
   flag:

--- a/json/test/flags/negative/with-invalid-flag-metadata.json
+++ b/json/test/flags/negative/with-invalid-flag-metadata.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../flags.json",
+  "flags": {
+    "myBoolFlag": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "on",
+      "metadata": {
+        "invalid": { "key": "value" }
+      }
+    }
+  }
+}

--- a/json/test/flags/negative/with-invalid-flag-set-metadata.json
+++ b/json/test/flags/negative/with-invalid-flag-set-metadata.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../flags.json",
+  "flags": {
+    "myBoolFlag": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "on"
+    }
+  },
+  "metadata": {
+    "invalid": { "key": "value" }
+  }
+}

--- a/json/test/flags/positive/with-metadata.json
+++ b/json/test/flags/positive/with-metadata.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../../flags.json",
+  "flags": {
+    "headerColor": {
+      "variants": {
+        "red": "#FF0000",
+        "blue": "#0000FF",
+        "green": "#00FF00",
+        "yellow": "#FFFF00"
+      },
+      "defaultVariant": "red",
+      "state": "ENABLED",
+      "metadata": {
+        "flagSetId": "blah",
+        "boolean": true,
+        "string": "string",
+        "float": 1.23,
+        "int": 1
+      }
+    }
+  },
+  "metadata": {
+    "flagSetId": "sso/dev",
+    "version": "1.0.0",
+    "boolean": true,
+    "string": "string",
+    "float": 1.23,
+    "int": 1
+  }
+}

--- a/json/test/flags/positive/with-metadata.json
+++ b/json/test/flags/positive/with-metadata.json
@@ -11,7 +11,6 @@
       "defaultVariant": "red",
       "state": "ENABLED",
       "metadata": {
-        "flagSetId": "blah",
         "boolean": true,
         "string": "string",
         "float": 1.23,
@@ -20,7 +19,7 @@
     }
   },
   "metadata": {
-    "flagSetId": "sso/dev",
+    "id": "sso/dev",
     "version": "1.0.0",
     "boolean": true,
     "string": "string",


### PR DESCRIPTION
## This PR

- adds flag metadata
- adds flag set metadata

### Notes

This lays the foundation for improved feature flag telemetry in flagd.

### Follow up

Update the protos to expose the metadata.
