### PR TITLE
feat: add metadata to the AnyFlag response used for bulk eval

### DIFF
--- a/protobuf/flagd/evaluation/v1/evaluation.proto
+++ b/protobuf/flagd/evaluation/v1/evaluation.proto
@@ -44,6 +44,9 @@ message AnyFlag {
     double double_value = 5;
     google.protobuf.Struct object_value = 6;
   }
+
+  // Metadata about this flag, see https://openfeature.dev/specification/types/#flag-metadata
+  google.protobuf.Struct metadata = 7;
 }
 
 // Request body for boolean flag evaluation, used by the ResolveBoolean rpc.


### PR DESCRIPTION
## This PR

- add metadata to the AnyFlag response used for bulk eval

### Related Issues

Fixes #174

### Notes

This brings the bulk evaluation API in line with a single evaluation.
