### PR TITLE
docs: fix url for flags.json

### DIFF
--- a/protobuf/flagd/sync/v1/sync.proto
+++ b/protobuf/flagd/sync/v1/sync.proto
@@ -35,7 +35,7 @@ message SyncFlagsRequest {
 
 // SyncFlagsResponse is the server response containing feature flag configurations and the state
 message SyncFlagsResponse {
-  // flagd feature flag configuration. Must be validated to schema - https://raw.githubusercontent.com/open-feature/schemas/main/json/flagd-definitions.json
+  // flagd feature flag configuration. Must be validated to schema - https://raw.githubusercontent.com/open-feature/flagd-schemas/main/json/flags.json
   string flag_configuration = 1;
 }
 
@@ -57,7 +57,7 @@ message FetchAllFlagsRequest {
 
 // FetchAllFlagsResponse is the server response containing feature flag configurations
 message FetchAllFlagsResponse {
-  // flagd feature flag configuration. Must be validated to schema - https://raw.githubusercontent.com/open-feature/schemas/main/json/flagd-definitions.json
+  // flagd feature flag configuration. Must be validated to schema - https://raw.githubusercontent.com/open-feature/flagd-schemas/main/json/flags.json
   string flag_configuration = 1;
 }
 

--- a/protobuf/sync/v1/sync_service.proto
+++ b/protobuf/sync/v1/sync_service.proto
@@ -58,7 +58,7 @@ enum SyncState {
 
 // SyncFlagsResponse is the server response containing feature flag configurations and the state
 message SyncFlagsResponse {
-  // flagd feature flag configuration. Must be validated to schema - https://raw.githubusercontent.com/open-feature/schemas/main/json/flagd-definitions.json
+  // flagd feature flag configuration. Must be validated to schema - https://raw.githubusercontent.com/open-feature/flagd-schemas/main/json/flags.json
   string flag_configuration = 1;
 
   // State conveying the operation to be performed by flagd. See the descriptions of SyncState for an explanation of
@@ -84,7 +84,7 @@ message FetchAllFlagsRequest {
 
 //  FetchAllFlagsResponse is the server response containing feature flag configurations
 message FetchAllFlagsResponse {
-  // flagd feature flag configuration. Must be validated to schema - https://raw.githubusercontent.com/open-feature/schemas/main/json/flagd-definitions.json
+  // flagd feature flag configuration. Must be validated to schema - https://raw.githubusercontent.com/open-feature/flagd-schemas/main/json/flags.json
   string flag_configuration = 1;
 }
 


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- fix url for flagd feature flag configuration json schema. because previous url is 404
	- from: https://raw.githubusercontent.com/open-feature/schemas/main/json/flagd-definitions.json
	- to: https://raw.githubusercontent.com/open-feature/flagd-schemas/main/json/flags.json

### Related PR

https://github.com/open-feature/flagd/pull/1553


