### PR TITLE
feat: add sync stream type and context

### DIFF
--- a/protobuf/flagd/sync/v1/sync.proto
+++ b/protobuf/flagd/sync/v1/sync.proto
@@ -37,6 +37,10 @@ message SyncFlagsRequest {
 message SyncFlagsResponse {
   // flagd feature flag configuration. Must be validated to schema - https://raw.githubusercontent.com/open-feature/schemas/main/json/flagd-definitions.json
   string flag_configuration = 1;
+  // String key indicating the type of event that is being received, for example, provider_ready or configuration_change
+  string type = 2;
+  // Static context to be included in in-process evaluations (optional).
+  optional google.protobuf.Struct sync_context = 3;
 }
 
 // FetchAllFlagsRequest is the request to fetch all flags. Clients send this request as the client in order to resync their internal state
@@ -62,17 +66,23 @@ message FetchAllFlagsResponse {
 }
 
 // GetMetadataRequest is the request for retrieving metadata from the sync service
-message GetMetadataRequest {}
+message GetMetadataRequest {
+  option deprecated = true;
+}
 
 // GetMetadataResponse contains metadata from the sync service
+// DEPRECATED; use flagd.sync.v1.SyncFlagsResponse.sync_context
 message GetMetadataResponse {
   reserved 1; // old key/value metadata impl
   google.protobuf.Struct metadata = 2;
+  option deprecated = true;
 }
 
 // FlagService implements a server streaming to provide realtime flag configurations
 service FlagSyncService {
   rpc SyncFlags(SyncFlagsRequest) returns (stream SyncFlagsResponse) {}
   rpc FetchAllFlags(FetchAllFlagsRequest) returns (FetchAllFlagsResponse) {}
-  rpc GetMetadata(GetMetadataRequest) returns (GetMetadataResponse) {}
+  rpc GetMetadata(GetMetadataRequest) returns (GetMetadataResponse) {
+    option deprecated = true;
+  }
 }

--- a/protobuf/flagd/sync/v1/sync.proto
+++ b/protobuf/flagd/sync/v1/sync.proto
@@ -37,10 +37,8 @@ message SyncFlagsRequest {
 message SyncFlagsResponse {
   // flagd feature flag configuration. Must be validated to schema - https://raw.githubusercontent.com/open-feature/schemas/main/json/flagd-definitions.json
   string flag_configuration = 1;
-  // String key indicating the type of event that is being received, for example, provider_ready or configuration_change
-  string type = 2;
   // Static context to be included in in-process evaluations (optional).
-  optional google.protobuf.Struct sync_context = 3;
+  optional google.protobuf.Struct sync_context = 2;
 }
 
 // FetchAllFlagsRequest is the request to fetch all flags. Clients send this request as the client in order to resync their internal state


### PR DESCRIPTION
This PR updates the sync schema. It:

- deprecates the [GetMetadata](https://buf.build/open-feature/flagd/docs/main:flagd.sync.v1#flagd.sync.v1.FlagSyncService.GetMetadata) rpc and its messages
- includes a new, **_optional_** `sync_context` field which conveys the same data as the now-deprecated GetMetadata rpc
  - `optional` makes it easy for providers to absorb this change in a non-breaking way, since it generates code which allows us to check if the the field is explicitly set or not, and if not, fall back to the old GetMetadata
- includes a new, **_required_** `type` field, exactly equivalent to the `type` field in the [EventStream](https://buf.build/open-feature/flagd/docs/main:flagd.evaluation.v1#flagd.evaluation.v1.EventStreamResponse)
  - this field must contain `provider_ready` on the first stream payload, and `configuration_change` in subsequent payloads
  - this field is required, **_meaning this is a breaking change for servers_** (they will need to be updated to check this field)
  - this allows providers to commonize more logic between sync/event stream implementations, and remove some state maintenance associated with sync stream implementations

Relates to: https://github.com/open-feature/flagd/issues/1584
Relates to: https://github.com/open-feature/flagd/issues/1585

In general, I'm wondering what people think of the name `sync_context` for the new field carrying the static context from flagd. My argument for `sync_context` is simple, in that it carries the auxiliary context from server and it's delivered via the sync stream. `static_context` might also work, but it might not be "static" in some implementations and could change in a new stream payload (though it won't in flagd). `GetMetadata` was poorly named, and I'm hoping this is clearer.

@cupofcat I believe you have your own server implementation, so I'm interested in your thoughts on both these changes.