### PR TITLE
fix: point buf-breaking against-ref at renamed flagd-schemas repo

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: bufbuild/buf-breaking-action@c57b3d842a5c3f3b454756ef65305a50a587c5ba # v1
         with:
           input: protobuf
-          against: 'https://github.com/open-feature/schemas.git#branch=main,ref=HEAD~1,subdir=protobuf'
+          against: 'https://github.com/open-feature/flagd-schemas.git#branch=main,ref=HEAD~1,subdir=protobuf'
 
   
   validate-schema:


### PR DESCRIPTION
The `buf-breaking-changes` check points `against` at `open-feature/schemas.git`, which was renamed to `open-feature/flagd-schemas`. The old URL 301-redirects and buf's clone handles it unreliably, so the check fails intermittently on nearly every PR. Points `against` at the current repo name.