### PR TITLE
feat!: cap numeric flag variants at IEEE-754 safe integer range

### DIFF
--- a/json/flags.json
+++ b/json/flags.json
@@ -196,7 +196,10 @@
           "additionalProperties": false,
           "patternProperties": {
             "^.{1,}$": {
-              "type": "number"
+              "type": "number",
+              "$comment": "bounded to the IEEE-754 double-precision safe integer range (+/-(2^53 - 1)) to ensure lossless representation across all supported languages",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
             }
           }
         }

--- a/json/flags.yaml
+++ b/json/flags.yaml
@@ -125,6 +125,9 @@ definitions:
         patternProperties:
           "^.{1,}$":
             type: number
+            $comment: bounded to the IEEE-754 double-precision safe integer range (+/-(2^53 - 1)) to ensure lossless representation across all supported languages
+            minimum: -9007199254740991
+            maximum: 9007199254740991
   objectVariants:
     type: object
     properties:

--- a/json/test/flags/negative/number-variant-exceeds-safe-integer-range.json
+++ b/json/test/flags/negative/number-variant-exceeds-safe-integer-range.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../../../flags.json",
+  "flags": {
+    "myIntFlag": {
+      "state": "ENABLED",
+      "variants": {
+        "tooBig": 9007199254740992
+      },
+      "defaultVariant": "tooBig"
+    }
+  }
+}

--- a/json/test/flags/positive/with-safe-integer-boundary-variants.json
+++ b/json/test/flags/positive/with-safe-integer-boundary-variants.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../../../flags.json",
+  "flags": {
+    "myIntFlag": {
+      "state": "ENABLED",
+      "variants": {
+        "min": -9007199254740991,
+        "max": 9007199254740991
+      },
+      "defaultVariant": "max"
+    }
+  }
+}


### PR DESCRIPTION
Implements the schema-level portion of the [numeric coercion ADR](https://github.com/open-feature/flagd/blob/main/docs/architecture-decisions/numeric-coercion.md).

- adds `minimum: -9007199254740991` / `maximum: 9007199254740991` to numeric variant values in `json/flags.yaml`, with a `$comment` recording why the bound exists (matching the inline-`$comment` convention already used elsewhere in the file)
- regenerates `json/flags.json` via `make gen-schema-json`; `targeting.json` and `flagd.json` come out byte-identical, so the diff is confined to the three new keys
- adds a positive fixture at both boundaries and a negative fixture at `9007199254740992`

Scope is `variants.*` only — `booleanVariants`, `stringVariants`, `objectVariants` and targeting values are untouched, per the issue.

This is an ordinary schema constraint. It does not introduce hard load-failure behaviour; flagd continues to surface schema violations as it does today. Hard-failing on schema violations is tracked separately.

`feat!:` because consumers that validate strictly may now reject previously-accepted out-of-range configs.

### Verification

`make test` passes. I also checked the negative fixture fails for the right reason rather than incidentally — the schema is an `anyOf` across variant types, so `--all-errors` shows the rejection landing on `#/definitions/numberVariants/properties/variants/patternProperties/.../maximum`, not only on the type mismatches from the other branches. Without this change the number branch would validate and the whole `anyOf` would pass.

Part of open-feature/flagd#1995.
