### PR TITLE
feat: deprecate flagd/evaluation/v1

### DIFF
--- a/protobuf/flagd/evaluation/v1/evaluation.proto
+++ b/protobuf/flagd/evaluation/v1/evaluation.proto
@@ -1,4 +1,5 @@
 /**
+ * DEPRECATED; use flagd.evaluation.v2
  * Flag evaluation API
  *
  * This proto forms the basis of a flag-evaluation API.
@@ -11,6 +12,7 @@ package flagd.evaluation.v1;
 
 import "google/protobuf/struct.proto";
 
+option deprecated = true;
 option csharp_namespace = "OpenFeature.Flagd.Grpc.Evaluation";
 option go_package = "flagd/evaluation/v1";
 option java_package = "dev.openfeature.flagd.grpc.evaluation";

--- a/protobuf/flagd/evaluation/v1/evaluation.proto
+++ b/protobuf/flagd/evaluation/v1/evaluation.proto
@@ -12,8 +12,8 @@ package flagd.evaluation.v1;
 
 import "google/protobuf/struct.proto";
 
-option deprecated = true;
 option csharp_namespace = "OpenFeature.Flagd.Grpc.Evaluation";
+option deprecated = true;
 option go_package = "flagd/evaluation/v1";
 option java_package = "dev.openfeature.flagd.grpc.evaluation";
 option php_namespace = "OpenFeature\\Providers\\Flagd\\Schema\\Grpc\\Evaluation";


### PR DESCRIPTION
* providers have migrated to v2
* no breaking changes - just marking for removal


--- 

The single exception is PHP, which has an open PR to update to this proto: github.com/open-feature/php-sdk-contrib/pull/176

Fixes: https://github.com/open-feature/flagd-schemas/issues/226